### PR TITLE
Backend lib readability

### DIFF
--- a/packages/backend/src/app/api/groups/[groupId]/bundle-candidates/route.ts
+++ b/packages/backend/src/app/api/groups/[groupId]/bundle-candidates/route.ts
@@ -1,21 +1,24 @@
-import { NextResponse } from "next/server";
-import { handleApiError } from "../../../../../lib/api-response";
-import { DEMO_ADMIN_USER_ID } from "../../../../../lib/demo-store";
-import { readBundleCandidates } from "../../../../../lib/group-service";
+import { NextResponse } from 'next/server';
+import { handleApiError } from '../../../../../lib/api-response';
+import { DEMO_ADMIN_ID } from '../../../../../lib/demo-store';
+import { getBundleCandidates } from '../../../../../lib/group-service';
 
-function getDemoRequestUserId(request: Request) {
+function getDemoUserId(request: Request) {
   // Demo-only fallback: lets the candidate endpoint show an admin view before OTP auth exists.
   // The service still checks that the resolved user belongs to the requested group.
-  return request.headers.get("x-user-id") ?? DEMO_ADMIN_USER_ID;
+  return request.headers.get('x-user-id') ?? DEMO_ADMIN_ID;
 }
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ groupId: string }> },
+  { params }: { params: Promise<{ groupId: string }> }
 ) {
   try {
     const { groupId } = await params;
-    const payload = readBundleCandidates(groupId, getDemoRequestUserId(request));
+    const payload = getBundleCandidates(
+      groupId,
+      getDemoUserId(request)
+    );
     return NextResponse.json(payload);
   } catch (error) {
     return handleApiError(error);

--- a/packages/backend/src/app/api/groups/[groupId]/settings/route.ts
+++ b/packages/backend/src/app/api/groups/[groupId]/settings/route.ts
@@ -1,21 +1,27 @@
-import { NextResponse } from "next/server";
-import { handleApiError } from "../../../../../lib/api-response";
-import { DEMO_ADMIN_USER_ID } from "../../../../../lib/demo-store";
-import { readGroupSettings, saveGroupSettings } from "../../../../../lib/group-service";
+import { NextResponse } from 'next/server';
+import { handleApiError } from '../../../../../lib/api-response';
+import { DEMO_ADMIN_ID } from '../../../../../lib/demo-store';
+import {
+  getGroupSettings,
+  updateGroupSettings
+} from '../../../../../lib/group-service';
 
-function getDemoRequestUserId(request: Request) {
+function getDemoUserId(request: Request) {
   // Demo-only fallback: the US7/US8 prototype can be opened without a real auth session.
   // Database-backed routes use lib/request-user.ts and require a UUID x-user-id header.
-  return request.headers.get("x-user-id") ?? DEMO_ADMIN_USER_ID;
+  return request.headers.get('x-user-id') ?? DEMO_ADMIN_ID;
 }
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ groupId: string }> },
+  { params }: { params: Promise<{ groupId: string }> }
 ) {
   try {
     const { groupId } = await params;
-    const payload = readGroupSettings(groupId, getDemoRequestUserId(request));
+    const payload = getGroupSettings(
+      groupId,
+      getDemoUserId(request)
+    );
     return NextResponse.json(payload);
   } catch (error) {
     return handleApiError(error);
@@ -24,7 +30,7 @@ export async function GET(
 
 export async function PATCH(
   request: Request,
-  { params }: { params: Promise<{ groupId: string }> },
+  { params }: { params: Promise<{ groupId: string }> }
 ) {
   try {
     const { groupId } = await params;
@@ -36,21 +42,38 @@ export async function PATCH(
 
     if (
       body.allowMissingIngredients !== undefined &&
-      typeof body.allowMissingIngredients !== "boolean"
+      typeof body.allowMissingIngredients !== 'boolean'
     ) {
-      return NextResponse.json({ error: "allowMissingIngredients must be a boolean." }, { status: 400 });
+      return NextResponse.json(
+        { error: 'allowMissingIngredients must be a boolean.' },
+        { status: 400 }
+      );
     }
 
-    if (body.staplesEnabled !== undefined && typeof body.staplesEnabled !== "boolean") {
-      return NextResponse.json({ error: "staplesEnabled must be a boolean." }, { status: 400 });
+    if (
+      body.staplesEnabled !== undefined &&
+      typeof body.staplesEnabled !== 'boolean'
+    ) {
+      return NextResponse.json(
+        { error: 'staplesEnabled must be a boolean.' },
+        { status: 400 }
+      );
     }
 
     if (
       body.customStaples !== undefined &&
       (!Array.isArray(body.customStaples) ||
-        body.customStaples.some((item) => typeof item !== "string"))
+        body.customStaples.some(
+          (item) => typeof item !== 'string'
+        ))
     ) {
-      return NextResponse.json({ error: "customStaples must be an array of ingredient ids." }, { status: 400 });
+      return NextResponse.json(
+        {
+          error:
+            'customStaples must be an array of ingredient ids.'
+        },
+        { status: 400 }
+      );
     }
 
     if (
@@ -58,16 +81,30 @@ export async function PATCH(
       body.staplesEnabled === undefined &&
       body.customStaples === undefined
     ) {
-      return NextResponse.json({ error: "No supported settings were provided." }, { status: 400 });
+      return NextResponse.json(
+        { error: 'No supported settings were provided.' },
+        { status: 400 }
+      );
     }
 
     // Only pass fields that survived validation; undefined means "do not change this setting."
-    const payload = saveGroupSettings(groupId, getDemoRequestUserId(request), {
-      allowMissingIngredients:
-        typeof body.allowMissingIngredients === "boolean" ? body.allowMissingIngredients : undefined,
-      staplesEnabled: typeof body.staplesEnabled === "boolean" ? body.staplesEnabled : undefined,
-      customStaples: Array.isArray(body.customStaples) ? body.customStaples : undefined,
-    });
+    const payload = updateGroupSettings(
+      groupId,
+      getDemoUserId(request),
+      {
+        allowMissingIngredients:
+          typeof body.allowMissingIngredients === 'boolean'
+            ? body.allowMissingIngredients
+            : undefined,
+        staplesEnabled:
+          typeof body.staplesEnabled === 'boolean'
+            ? body.staplesEnabled
+            : undefined,
+        customStaples: Array.isArray(body.customStaples)
+          ? body.customStaples
+          : undefined
+      }
+    );
 
     return NextResponse.json(payload);
   } catch (error) {

--- a/packages/backend/src/app/api/ingredient-catalog/route.ts
+++ b/packages/backend/src/app/api/ingredient-catalog/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { handleApiError } from '../../../lib/api-response';
+import { listIngredientOptions } from '../../../lib/ingredient-service';
+
+// GET /api/ingredient-catalog returns canonical dropdown choices for pantry items.
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const ingredientOptions = await listIngredientOptions(
+      searchParams.get('search') ?? undefined
+    );
+
+    return NextResponse.json({
+      ingredients: ingredientOptions
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/packages/backend/src/app/api/ingredients/[ingredientId]/route.ts
+++ b/packages/backend/src/app/api/ingredients/[ingredientId]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { handleApiError } from '../../../../lib/api-response';
 import {
-  deleteIngredient,
-  updateIngredient
+  deletePantryItem,
+  updatePantryItem
 } from '../../../../lib/ingredient-service';
 import { getRequestUserId } from '../../../../lib/request-user';
 
@@ -13,14 +13,14 @@ export async function PATCH(
   { params }: { params: Promise<{ ingredientId: string }> }
 ) {
   try {
-    const { ingredientId } = await params;
-    const ingredient = await updateIngredient(
+    const { ingredientId: pantryItemId } = await params;
+    const pantryItem = await updatePantryItem(
       getRequestUserId(request),
-      ingredientId,
+      pantryItemId,
       await request.json()
     );
 
-    return NextResponse.json(ingredient);
+    return NextResponse.json(pantryItem);
   } catch (error) {
     return handleApiError(error);
   }
@@ -31,10 +31,10 @@ export async function DELETE(
   { params }: { params: Promise<{ ingredientId: string }> }
 ) {
   try {
-    const { ingredientId } = await params;
-    await deleteIngredient(
+    const { ingredientId: pantryItemId } = await params;
+    await deletePantryItem(
       getRequestUserId(request),
-      ingredientId
+      pantryItemId
     );
 
     return new Response(null, { status: 204 });

--- a/packages/backend/src/app/api/ingredients/route.ts
+++ b/packages/backend/src/app/api/ingredients/route.ts
@@ -1,20 +1,20 @@
 import { NextResponse } from 'next/server';
 import { handleApiError } from '../../../lib/api-response';
 import {
-  createIngredient,
-  listIngredients
+  addPantryItem,
+  listPantryItems
 } from '../../../lib/ingredient-service';
 import { getRequestUserId } from '../../../lib/request-user';
 
-// These routes currently treat "ingredients" as a user's pantry items.
-// A future canonical ingredient database should probably use a separate route name.
+// These routes keep the old /api/ingredients URL, but the records are now
+// user-owned pantry items linked to canonical ingredient catalog entries.
 export async function GET(request: Request) {
   try {
-    const ingredients = await listIngredients(
+    const pantryItems = await listPantryItems(
       getRequestUserId(request)
     );
 
-    return NextResponse.json({ ingredients });
+    return NextResponse.json({ ingredients: pantryItems });
   } catch (error) {
     return handleApiError(error);
   }
@@ -23,12 +23,12 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     // The owner comes from the request header, not the body, so users cannot create pantry items for someone else.
-    const ingredient = await createIngredient(
+    const pantryItem = await addPantryItem(
       getRequestUserId(request),
       await request.json()
     );
 
-    return NextResponse.json(ingredient, { status: 201 });
+    return NextResponse.json(pantryItem, { status: 201 });
   } catch (error) {
     return handleApiError(error);
   }

--- a/packages/backend/src/app/api/profiles/[profileId]/route.ts
+++ b/packages/backend/src/app/api/profiles/[profileId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handleApiError } from '../../../../lib/api-response';
-import { readProfile } from '../../../../lib/profile-service';
+import { getProfile } from '../../../../lib/profile-service';
 
 // GET /api/profiles/[profileId] is a direct lookup route; [profileId] comes from the folder name.
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   try {
     const { profileId } = await params;
-    const profile = await readProfile(profileId);
+    const profile = await getProfile(profileId);
 
     return NextResponse.json(profile);
   } catch (error) {

--- a/packages/backend/src/app/api/profiles/me/route.ts
+++ b/packages/backend/src/app/api/profiles/me/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { handleApiError } from '../../../../lib/api-response';
-import { readProfile } from '../../../../lib/profile-service';
+import { getProfile } from '../../../../lib/profile-service';
 import { getRequestUserId } from '../../../../lib/request-user';
 
 // GET /api/profiles/me reads the caller from x-user-id until the SRD's OTP session flow exists.
 export async function GET(request: Request) {
   try {
-    const profile = await readProfile(
-      getRequestUserId(request)
-    );
+    const profile = await getProfile(getRequestUserId(request));
 
     return NextResponse.json(profile);
   } catch (error) {

--- a/packages/backend/src/lib/api-error.ts
+++ b/packages/backend/src/lib/api-error.ts
@@ -4,7 +4,16 @@ export class ApiError extends Error {
 
   constructor(statusCode: number, message: string) {
     super(message);
-    this.name = "ApiError";
+    this.name = 'ApiError';
     this.statusCode = statusCode;
   }
+}
+
+export function isPrismaError(error: unknown, code: string) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === code
+  );
 }

--- a/packages/backend/src/lib/bundle-validator.ts
+++ b/packages/backend/src/lib/bundle-validator.ts
@@ -1,183 +1,217 @@
 import {
-  getDefaultStaplesPreset,
-  resolveIngredientIds,
-  type BundleIngredient,
-  type BundleTemplate,
-  type GroupRecord,
-  type PantryItem,
-} from "./demo-store";
+  getDefaultStaples,
+  getIngredientsById,
+  type IngredientNeed,
+  type Bundle,
+  type DemoGroup,
+  type PantryItem
+} from './demo-store';
 
 // Candidate validation for US7/US8: apply group missing-ingredient and staples settings
 // before returning bundles to the UI.
-export type MissingIngredientDisclosure = {
+export type MissingIngredient = {
   ingredientId: string;
   name: string;
   quantityNeeded: number;
   unit: string;
 };
 
-export type ContributorAllocation = {
+export type Contribution = {
   userId: string;
   userName: string;
   quantity: number;
   unit: string;
 };
 
-export type ValidationReport = {
+export type CandidateCheck = {
   isValid: boolean;
-  reason: "ok" | "missing_ingredients";
-  missingIngredients: MissingIngredientDisclosure[];
+  reason: 'ok' | 'missing_ingredients';
+  missingIngredients: MissingIngredient[];
 };
 
-export type ValidatedBundleCandidate = BundleTemplate & {
-  contributorMapping: Record<string, ContributorAllocation[]>;
-  missingIngredients: MissingIngredientDisclosure[];
+export type BundleCandidate = Bundle & {
+  contributorMapping: Record<string, Contribution[]>;
+  missingIngredients: MissingIngredient[];
   assumedStaples: Array<{ ingredientId: string; name: string }>;
-  validationReport: ValidationReport;
+  validationReport: CandidateCheck;
 };
 
-export type ValidatedCandidateSet = {
-  candidates: ValidatedBundleCandidate[];
+export type CandidateList = {
+  candidates: BundleCandidate[];
   filteredOutCandidateCount: number;
 };
 
-function buildIngredientDisclosure(ingredient: BundleIngredient): MissingIngredientDisclosure {
+function missingIngredientFrom(
+  need: IngredientNeed
+): MissingIngredient {
   return {
-    ingredientId: ingredient.ingredientId,
-    name: ingredient.name,
-    quantityNeeded: ingredient.quantity,
-    unit: ingredient.unit,
+    ingredientId: need.ingredientId,
+    name: need.name,
+    quantityNeeded: need.quantity,
+    unit: need.unit
   };
 }
 
-function getEnabledStapleIds(group: GroupRecord) {
+function getStapleIds(group: DemoGroup) {
   if (!group.staplesEnabled) {
     return new Set<string>();
   }
 
   const stapleIds = [
-    ...getDefaultStaplesPreset().map((item) => item.id),
-    ...resolveIngredientIds(group.customStaples).map((item) => item.id),
+    ...getDefaultStaples().map((item) => item.id),
+    ...getIngredientsById(group.customStaples).map(
+      (item) => item.id
+    )
   ];
 
   return new Set(stapleIds);
 }
 
-function buildContributorMapping(
-  ingredient: BundleIngredient,
+function findContributors(
+  need: IngredientNeed,
   pantry: PantryItem[],
-  enabledStapleIds: Set<string>,
+  stapleIds: Set<string>
 ) {
-  if (enabledStapleIds.has(ingredient.ingredientId)) {
+  if (stapleIds.has(need.ingredientId)) {
     // Staples are treated as a group-level unlimited source rather than one member's pantry item.
     return [
       {
-        userId: "group-staples",
-        userName: "Group staples",
-        quantity: ingredient.quantity,
-        unit: ingredient.unit,
-      },
+        userId: 'group-staples',
+        userName: 'Group staples',
+        quantity: need.quantity,
+        unit: need.unit
+      }
     ];
   }
 
-  const matchingItems = pantry
-    .filter((item) => item.ingredientId === ingredient.ingredientId && item.unit === ingredient.unit)
-    .sort((left, right) => left.ownerName.localeCompare(right.ownerName));
+  const matchingPantry = pantry
+    .filter(
+      (item) =>
+        item.ingredientId === need.ingredientId &&
+        item.unit === need.unit
+    )
+    .sort((left, right) =>
+      left.ownerName.localeCompare(right.ownerName)
+    );
 
-  let remaining = ingredient.quantity;
-  const allocations: ContributorAllocation[] = [];
+  let remaining = need.quantity;
+  const contributors: Contribution[] = [];
 
-  for (const item of matchingItems) {
+  for (const item of matchingPantry) {
     if (remaining <= 0) {
       break;
     }
 
-    const allocationQuantity = Math.min(item.quantity, remaining);
-    allocations.push({
+    const amount = Math.min(item.quantity, remaining);
+    contributors.push({
       userId: item.ownerUserId,
       userName: item.ownerName,
-      quantity: allocationQuantity,
-      unit: item.unit,
+      quantity: amount,
+      unit: item.unit
     });
-    remaining -= allocationQuantity;
+    remaining -= amount;
   }
 
-  return allocations;
+  return contributors;
 }
 
-function validateBundleCandidate(
-  group: GroupRecord,
-  template: BundleTemplate,
+function checkBundle(
+  group: DemoGroup,
+  bundle: Bundle,
   pantry: PantryItem[],
-  allowMissingIngredients: boolean,
-): { visible: boolean; candidate: ValidatedBundleCandidate } {
-  const enabledStapleIds = getEnabledStapleIds(group);
+  allowMissingIngredients: boolean
+): { visible: boolean; candidate: BundleCandidate } {
+  const stapleIds = getStapleIds(group);
   const contributorMapping = Object.fromEntries(
-    template.ingredientList.map((ingredient) => [
-      ingredient.ingredientId,
-      buildContributorMapping(ingredient, pantry, enabledStapleIds),
-    ]),
+    bundle.ingredientList.map((need) => [
+      need.ingredientId,
+      findContributors(need, pantry, stapleIds)
+    ])
   );
 
-  const assumedStaples = template.ingredientList
-    .filter((ingredient) => enabledStapleIds.has(ingredient.ingredientId))
-    .map((ingredient) => ({
-      ingredientId: ingredient.ingredientId,
-      name: ingredient.name,
+  const assumedStaples = bundle.ingredientList
+    .filter((need) => stapleIds.has(need.ingredientId))
+    .map((need) => ({
+      ingredientId: need.ingredientId,
+      name: need.name
     }));
 
-  const missingIngredients = template.ingredientList
-    .filter((ingredient) => {
-      if (enabledStapleIds.has(ingredient.ingredientId)) {
+  const missingIngredients = bundle.ingredientList
+    .filter((need) => {
+      if (stapleIds.has(need.ingredientId)) {
         return false;
       }
 
-      const matchingQuantity = pantry
-        .filter((item) => item.ingredientId === ingredient.ingredientId && item.unit === ingredient.unit)
+      const available = pantry
+        .filter(
+          (item) =>
+            item.ingredientId === need.ingredientId &&
+            item.unit === need.unit
+        )
         .reduce((sum, item) => sum + item.quantity, 0);
 
-      return matchingQuantity < ingredient.quantity;
+      return available < need.quantity;
     })
-    .map(buildIngredientDisclosure);
+    .map(missingIngredientFrom);
 
-  const validationReport: ValidationReport = {
-    isValid: allowMissingIngredients || missingIngredients.length === 0,
-    reason: missingIngredients.length === 0 ? "ok" : "missing_ingredients",
-    missingIngredients,
+  const check: CandidateCheck = {
+    isValid:
+      allowMissingIngredients ||
+      missingIngredients.length === 0,
+    reason:
+      missingIngredients.length === 0
+        ? 'ok'
+        : 'missing_ingredients',
+    missingIngredients
   };
 
-  const candidate: ValidatedBundleCandidate = {
-    ...template,
+  const candidate: BundleCandidate = {
+    ...bundle,
     contributorMapping,
     missingIngredients,
     assumedStaples,
-    validationReport,
+    validationReport: check,
     rationale: [
-      template.rationale,
+      bundle.rationale,
       assumedStaples.length > 0
-        ? `Assumed staples: ${assumedStaples.map((item) => item.name).join(", ")}.`
-        : "",
+        ? `Assumed staples: ${assumedStaples.map((item) => item.name).join(', ')}.`
+        : '',
       allowMissingIngredients && missingIngredients.length > 0
-        ? "Missing items are disclosed so the group can decide whether shopping is worth it."
-        : "",
+        ? 'Missing items are disclosed so the group can decide whether shopping is worth it.'
+        : ''
     ]
       .filter(Boolean)
-      .join(" "),
+      .join(' ')
   };
 
   return {
-    visible: allowMissingIngredients || missingIngredients.length === 0,
-    candidate,
+    visible:
+      allowMissingIngredients ||
+      missingIngredients.length === 0,
+    candidate
   };
 }
 
-export function buildValidatedCandidateSet(group: GroupRecord, templates: BundleTemplate[], pantry: PantryItem[]): ValidatedCandidateSet {
-  const results = templates.map((template) =>
-    validateBundleCandidate(group, template, pantry, group.allowMissingIngredients),
+export function buildCandidateList(
+  group: DemoGroup,
+  bundles: Bundle[],
+  pantry: PantryItem[]
+): CandidateList {
+  const checkedBundles = bundles.map((bundle) =>
+    checkBundle(
+      group,
+      bundle,
+      pantry,
+      group.allowMissingIngredients
+    )
   );
 
   return {
-    candidates: results.filter((result) => result.visible).map((result) => result.candidate),
-    filteredOutCandidateCount: results.filter((result) => !result.visible).length,
+    candidates: checkedBundles
+      .filter((result) => result.visible)
+      .map((result) => result.candidate),
+    filteredOutCandidateCount: checkedBundles.filter(
+      (result) => !result.visible
+    ).length
   };
 }

--- a/packages/backend/src/lib/demo-store.ts
+++ b/packages/backend/src/lib/demo-store.ts
@@ -1,6 +1,6 @@
 // Temporary in-memory data for the US7/US8 demo routes.
 // Database-backed equivalents should eventually move into Prisma models and services.
-export type GroupRole = "admin" | "member";
+export type GroupRole = 'admin' | 'member';
 
 export type GroupMember = {
   userId: string;
@@ -8,7 +8,7 @@ export type GroupMember = {
   role: GroupRole;
 };
 
-export type GroupRecord = {
+export type DemoGroup = {
   id: string;
   name: string;
   allowMissingIngredients: boolean;
@@ -18,7 +18,7 @@ export type GroupRecord = {
   members: GroupMember[];
 };
 
-export type IngredientCatalogItem = {
+export type IngredientOption = {
   id: string;
   name: string;
 };
@@ -32,287 +32,444 @@ export type PantryItem = {
   ownerName: string;
 };
 
-export type BundleCourseType = "appetizer" | "main" | "side" | "dessert";
+export type CourseType =
+  | 'appetizer'
+  | 'main'
+  | 'side'
+  | 'dessert';
 
-export type BundleCourse = {
-  type: BundleCourseType;
+export type Course = {
+  type: CourseType;
   title: string;
 };
 
-export type BundleIngredient = {
+export type IngredientNeed = {
   ingredientId: string;
   name: string;
   quantity: number;
   unit: string;
 };
 
-export type BundleTemplate = {
+export type Bundle = {
   id: string;
   title: string;
-  courses: BundleCourse[];
-  ingredientList: BundleIngredient[];
+  courses: Course[];
+  ingredientList: IngredientNeed[];
   instructions: string[];
   rationale: string;
 };
 
-export const DEMO_ADMIN_USER_ID = "user-admin-1";
-export const DEMO_MEMBER_USER_ID = "user-member-1";
+export const DEMO_ADMIN_ID = 'user-admin-1';
+export const DEMO_MEMBER_ID = 'user-member-1';
 
-const INGREDIENT_CATALOG: IngredientCatalogItem[] = [
-  { id: "olive-oil", name: "Olive oil" },
-  { id: "butter", name: "Butter" },
-  { id: "salt", name: "Salt" },
-  { id: "pepper", name: "Pepper" },
-  { id: "basil-leaves", name: "Basil leaves" },
-  { id: "thyme", name: "Fresh thyme" },
-  { id: "sesame-oil", name: "Sesame oil" },
-  { id: "parmesan", name: "Parmesan" },
-  { id: "saffron-threads", name: "Saffron threads" },
-  { id: "bread-loaf", name: "Bread loaf" },
-  { id: "tomatoes", name: "Tomatoes" },
-  { id: "garlic-cloves", name: "Garlic" },
-  { id: "pasta", name: "Pasta" },
-  { id: "chicken-fillets", name: "Chicken fillets" },
-  { id: "mushrooms", name: "Mushrooms" },
-  { id: "cream", name: "Cream" },
+const INGREDIENTS: IngredientOption[] = [
+  { id: 'olive-oil', name: 'Olive oil' },
+  { id: 'butter', name: 'Butter' },
+  { id: 'salt', name: 'Salt' },
+  { id: 'pepper', name: 'Pepper' },
+  { id: 'basil-leaves', name: 'Basil leaves' },
+  { id: 'thyme', name: 'Fresh thyme' },
+  { id: 'sesame-oil', name: 'Sesame oil' },
+  { id: 'parmesan', name: 'Parmesan' },
+  { id: 'saffron-threads', name: 'Saffron threads' },
+  { id: 'bread-loaf', name: 'Bread loaf' },
+  { id: 'tomatoes', name: 'Tomatoes' },
+  { id: 'garlic-cloves', name: 'Garlic' },
+  { id: 'pasta', name: 'Pasta' },
+  { id: 'chicken-fillets', name: 'Chicken fillets' },
+  { id: 'mushrooms', name: 'Mushrooms' },
+  { id: 'cream', name: 'Cream' }
 ];
 
-const DEFAULT_STAPLES_PRESET_IDS = ["olive-oil", "butter", "salt", "pepper"];
+const DEFAULT_STAPLE_IDS = [
+  'olive-oil',
+  'butter',
+  'salt',
+  'pepper'
+];
 
-type DemoState = {
-  groups: Map<string, GroupRecord>;
-  pantriesByGroup: Map<string, PantryItem[]>;
-  bundleTemplatesByGroup: Map<string, BundleTemplate[]>;
+type DemoStore = {
+  groups: Map<string, DemoGroup>;
+  pantryByGroup: Map<string, PantryItem[]>;
+  bundlesByGroup: Map<string, Bundle[]>;
 };
 
-function createDemoState(): DemoState {
-  const groupId = "dorm-dinner-crew";
+function createDemoStore(): DemoStore {
+  const groupId = 'dorm-dinner-crew';
 
-  const groups = new Map<string, GroupRecord>([
+  const groups = new Map<string, DemoGroup>([
     [
       groupId,
       {
         id: groupId,
-        name: "Dorm Dinner Crew",
+        name: 'Dorm Dinner Crew',
         allowMissingIngredients: false,
         staplesEnabled: false,
         customStaples: [],
-        updatedAt: "2026-05-11T07:00:00.000Z",
+        updatedAt: '2026-05-11T07:00:00.000Z',
         members: [
-          { userId: DEMO_ADMIN_USER_ID, name: "Vinayak", role: "admin" },
-          { userId: DEMO_MEMBER_USER_ID, name: "Kartik", role: "member" },
-          { userId: "user-member-2", name: "Ani", role: "member" },
-        ],
-      },
-    ],
+          {
+            userId: DEMO_ADMIN_ID,
+            name: 'Vinayak',
+            role: 'admin'
+          },
+          {
+            userId: DEMO_MEMBER_ID,
+            name: 'Kartik',
+            role: 'member'
+          },
+          {
+            userId: 'user-member-2',
+            name: 'Ani',
+            role: 'member'
+          }
+        ]
+      }
+    ]
   ]);
 
-  const pantriesByGroup = new Map<string, PantryItem[]>([
+  const pantryByGroup = new Map<string, PantryItem[]>([
     [
       groupId,
       [
         {
-          ingredientId: "chicken-fillets",
-          name: "Chicken fillets",
+          ingredientId: 'chicken-fillets',
+          name: 'Chicken fillets',
           quantity: 2,
-          unit: "fillets",
-          ownerUserId: DEMO_ADMIN_USER_ID,
-          ownerName: "Vinayak",
+          unit: 'fillets',
+          ownerUserId: DEMO_ADMIN_ID,
+          ownerName: 'Vinayak'
         },
         {
-          ingredientId: "mushrooms",
-          name: "Mushrooms",
+          ingredientId: 'mushrooms',
+          name: 'Mushrooms',
           quantity: 2,
-          unit: "cups",
-          ownerUserId: DEMO_MEMBER_USER_ID,
-          ownerName: "Kartik",
+          unit: 'cups',
+          ownerUserId: DEMO_MEMBER_ID,
+          ownerName: 'Kartik'
         },
         {
-          ingredientId: "cream",
-          name: "Cream",
+          ingredientId: 'cream',
+          name: 'Cream',
           quantity: 1,
-          unit: "cups",
-          ownerUserId: DEMO_MEMBER_USER_ID,
-          ownerName: "Kartik",
+          unit: 'cups',
+          ownerUserId: DEMO_MEMBER_ID,
+          ownerName: 'Kartik'
         },
         {
-          ingredientId: "garlic-cloves",
-          name: "Garlic",
+          ingredientId: 'garlic-cloves',
+          name: 'Garlic',
           quantity: 8,
-          unit: "cloves",
-          ownerUserId: "user-member-2",
-          ownerName: "Ani",
+          unit: 'cloves',
+          ownerUserId: 'user-member-2',
+          ownerName: 'Ani'
         },
         {
-          ingredientId: "tomatoes",
-          name: "Tomatoes",
+          ingredientId: 'tomatoes',
+          name: 'Tomatoes',
           quantity: 6,
-          unit: "whole",
-          ownerUserId: DEMO_ADMIN_USER_ID,
-          ownerName: "Vinayak",
+          unit: 'whole',
+          ownerUserId: DEMO_ADMIN_ID,
+          ownerName: 'Vinayak'
         },
         {
-          ingredientId: "pasta",
-          name: "Pasta",
+          ingredientId: 'pasta',
+          name: 'Pasta',
           quantity: 2,
-          unit: "boxes",
-          ownerUserId: "user-member-2",
-          ownerName: "Ani",
+          unit: 'boxes',
+          ownerUserId: 'user-member-2',
+          ownerName: 'Ani'
         },
         {
-          ingredientId: "bread-loaf",
-          name: "Bread loaf",
+          ingredientId: 'bread-loaf',
+          name: 'Bread loaf',
           quantity: 1,
-          unit: "loaf",
-          ownerUserId: DEMO_ADMIN_USER_ID,
-          ownerName: "Vinayak",
-        },
-      ],
-    ],
+          unit: 'loaf',
+          ownerUserId: DEMO_ADMIN_ID,
+          ownerName: 'Vinayak'
+        }
+      ]
+    ]
   ]);
 
-  const bundleTemplatesByGroup = new Map<string, BundleTemplate[]>([
+  const bundlesByGroup = new Map<string, Bundle[]>([
     [
       groupId,
       [
         {
-          id: "bundle-creamy-tuscan-night",
-          title: "Creamy Tuscan Night",
+          id: 'bundle-creamy-tuscan-night',
+          title: 'Creamy Tuscan Night',
           courses: [
-            { type: "appetizer", title: "Garlic Tomato Toasts" },
-            { type: "main", title: "Creamy Tuscan Chicken" },
+            {
+              type: 'appetizer',
+              title: 'Garlic Tomato Toasts'
+            },
+            { type: 'main', title: 'Creamy Tuscan Chicken' }
           ],
           ingredientList: [
-            { ingredientId: "bread-loaf", name: "Bread loaf", quantity: 1, unit: "loaf" },
-            { ingredientId: "tomatoes", name: "Tomatoes", quantity: 2, unit: "whole" },
-            { ingredientId: "garlic-cloves", name: "Garlic", quantity: 3, unit: "cloves" },
-            { ingredientId: "chicken-fillets", name: "Chicken fillets", quantity: 2, unit: "fillets" },
-            { ingredientId: "mushrooms", name: "Mushrooms", quantity: 1, unit: "cups" },
-            { ingredientId: "cream", name: "Cream", quantity: 1, unit: "cups" },
+            {
+              ingredientId: 'bread-loaf',
+              name: 'Bread loaf',
+              quantity: 1,
+              unit: 'loaf'
+            },
+            {
+              ingredientId: 'tomatoes',
+              name: 'Tomatoes',
+              quantity: 2,
+              unit: 'whole'
+            },
+            {
+              ingredientId: 'garlic-cloves',
+              name: 'Garlic',
+              quantity: 3,
+              unit: 'cloves'
+            },
+            {
+              ingredientId: 'chicken-fillets',
+              name: 'Chicken fillets',
+              quantity: 2,
+              unit: 'fillets'
+            },
+            {
+              ingredientId: 'mushrooms',
+              name: 'Mushrooms',
+              quantity: 1,
+              unit: 'cups'
+            },
+            {
+              ingredientId: 'cream',
+              name: 'Cream',
+              quantity: 1,
+              unit: 'cups'
+            }
           ],
           instructions: [
-            "Toast the bread and rub it with garlic for the appetizer base.",
-            "Simmer the chicken with mushrooms, tomatoes, and cream until the sauce thickens.",
+            'Toast the bread and rub it with garlic for the appetizer base.',
+            'Simmer the chicken with mushrooms, tomatoes, and cream until the sauce thickens.'
           ],
-          rationale: "Fits a cozy shared dinner using ingredients already in the group pantry.",
+          rationale:
+            'Fits a cozy shared dinner using ingredients already in the group pantry.'
         },
         {
-          id: "bundle-saffron-pasta-night",
-          title: "Saffron Pasta Night",
+          id: 'bundle-saffron-pasta-night',
+          title: 'Saffron Pasta Night',
           courses: [
-            { type: "main", title: "Saffron Tomato Pasta" },
-            { type: "side", title: "Warm Herb Bread" },
+            { type: 'main', title: 'Saffron Tomato Pasta' },
+            { type: 'side', title: 'Warm Herb Bread' }
           ],
           ingredientList: [
-            { ingredientId: "pasta", name: "Pasta", quantity: 1, unit: "boxes" },
-            { ingredientId: "tomatoes", name: "Tomatoes", quantity: 3, unit: "whole" },
-            { ingredientId: "garlic-cloves", name: "Garlic", quantity: 2, unit: "cloves" },
-            { ingredientId: "saffron-threads", name: "Saffron threads", quantity: 1, unit: "tbsp" },
-            { ingredientId: "salt", name: "Salt", quantity: 1, unit: "tsp" },
-            { ingredientId: "bread-loaf", name: "Bread loaf", quantity: 1, unit: "loaf" },
+            {
+              ingredientId: 'pasta',
+              name: 'Pasta',
+              quantity: 1,
+              unit: 'boxes'
+            },
+            {
+              ingredientId: 'tomatoes',
+              name: 'Tomatoes',
+              quantity: 3,
+              unit: 'whole'
+            },
+            {
+              ingredientId: 'garlic-cloves',
+              name: 'Garlic',
+              quantity: 2,
+              unit: 'cloves'
+            },
+            {
+              ingredientId: 'saffron-threads',
+              name: 'Saffron threads',
+              quantity: 1,
+              unit: 'tbsp'
+            },
+            {
+              ingredientId: 'salt',
+              name: 'Salt',
+              quantity: 1,
+              unit: 'tsp'
+            },
+            {
+              ingredientId: 'bread-loaf',
+              name: 'Bread loaf',
+              quantity: 1,
+              unit: 'loaf'
+            }
           ],
           instructions: [
-            "Boil the pasta and build a tomato sauce with garlic.",
-            "Finish the sauce with saffron threads and serve with warm bread.",
+            'Boil the pasta and build a tomato sauce with garlic.',
+            'Finish the sauce with saffron threads and serve with warm bread.'
           ],
-          rationale: "A pasta-forward bundle with a fancier flavor profile for a weekend group meal.",
+          rationale:
+            'A pasta-forward bundle with a fancier flavor profile for a weekend group meal.'
         },
         {
-          id: "bundle-garden-pasta-board",
-          title: "Garden Pasta Board",
+          id: 'bundle-garden-pasta-board',
+          title: 'Garden Pasta Board',
           courses: [
-            { type: "main", title: "Garlic Garden Pasta" },
-            { type: "side", title: "Toasted Bread Board" },
+            { type: 'main', title: 'Garlic Garden Pasta' },
+            { type: 'side', title: 'Toasted Bread Board' }
           ],
           ingredientList: [
-            { ingredientId: "pasta", name: "Pasta", quantity: 1, unit: "boxes" },
-            { ingredientId: "tomatoes", name: "Tomatoes", quantity: 2, unit: "whole" },
-            { ingredientId: "garlic-cloves", name: "Garlic", quantity: 2, unit: "cloves" },
-            { ingredientId: "olive-oil", name: "Olive oil", quantity: 2, unit: "tbsp" },
-            { ingredientId: "salt", name: "Salt", quantity: 1, unit: "tsp" },
-            { ingredientId: "bread-loaf", name: "Bread loaf", quantity: 1, unit: "loaf" },
+            {
+              ingredientId: 'pasta',
+              name: 'Pasta',
+              quantity: 1,
+              unit: 'boxes'
+            },
+            {
+              ingredientId: 'tomatoes',
+              name: 'Tomatoes',
+              quantity: 2,
+              unit: 'whole'
+            },
+            {
+              ingredientId: 'garlic-cloves',
+              name: 'Garlic',
+              quantity: 2,
+              unit: 'cloves'
+            },
+            {
+              ingredientId: 'olive-oil',
+              name: 'Olive oil',
+              quantity: 2,
+              unit: 'tbsp'
+            },
+            {
+              ingredientId: 'salt',
+              name: 'Salt',
+              quantity: 1,
+              unit: 'tsp'
+            },
+            {
+              ingredientId: 'bread-loaf',
+              name: 'Bread loaf',
+              quantity: 1,
+              unit: 'loaf'
+            }
           ],
           instructions: [
-            "Boil the pasta and toss it with tomatoes, garlic, and olive oil.",
-            "Season with salt and serve with thick slices of toasted bread.",
+            'Boil the pasta and toss it with tomatoes, garlic, and olive oil.',
+            'Season with salt and serve with thick slices of toasted bread.'
           ],
-          rationale: "A pantry-driven pasta board that works well if the household treats common basics as staples.",
+          rationale:
+            'A pantry-driven pasta board that works well if the household treats common basics as staples.'
         },
         {
-          id: "bundle-bruschetta-board",
-          title: "Bruschetta Board",
+          id: 'bundle-bruschetta-board',
+          title: 'Bruschetta Board',
           courses: [
-            { type: "appetizer", title: "Tomato Basil Bruschetta" },
-            { type: "side", title: "Herb Salad" },
+            {
+              type: 'appetizer',
+              title: 'Tomato Basil Bruschetta'
+            },
+            { type: 'side', title: 'Herb Salad' }
           ],
           ingredientList: [
-            { ingredientId: "bread-loaf", name: "Bread loaf", quantity: 1, unit: "loaf" },
-            { ingredientId: "tomatoes", name: "Tomatoes", quantity: 4, unit: "whole" },
-            { ingredientId: "garlic-cloves", name: "Garlic", quantity: 1, unit: "cloves" },
-            { ingredientId: "basil-leaves", name: "Basil leaves", quantity: 10, unit: "leaves" },
+            {
+              ingredientId: 'bread-loaf',
+              name: 'Bread loaf',
+              quantity: 1,
+              unit: 'loaf'
+            },
+            {
+              ingredientId: 'tomatoes',
+              name: 'Tomatoes',
+              quantity: 4,
+              unit: 'whole'
+            },
+            {
+              ingredientId: 'garlic-cloves',
+              name: 'Garlic',
+              quantity: 1,
+              unit: 'cloves'
+            },
+            {
+              ingredientId: 'basil-leaves',
+              name: 'Basil leaves',
+              quantity: 10,
+              unit: 'leaves'
+            }
           ],
           instructions: [
-            "Toast the bread and top with chopped tomatoes and garlic.",
-            "Scatter basil leaves over the board right before serving.",
+            'Toast the bread and top with chopped tomatoes and garlic.',
+            'Scatter basil leaves over the board right before serving.'
           ],
-          rationale: "Simple crowd-pleaser that becomes viable if the group is willing to shop for a fresh herb.",
-        },
-      ],
-    ],
+          rationale:
+            'Simple crowd-pleaser that becomes viable if the group is willing to shop for a fresh herb.'
+        }
+      ]
+    ]
   ]);
 
-  return { groups, pantriesByGroup, bundleTemplatesByGroup };
+  return { groups, pantryByGroup, bundlesByGroup };
 }
 
-let demoState = createDemoState();
+let demoStore = createDemoStore();
 
-export function resetDemoState() {
-  // Tests use this to avoid one test's PATCH changing the next test's starting state.
-  demoState = createDemoState();
+export function resetDemoStore() {
+  // Tests use this to avoid one test's PATCH changing the next test's store.
+  demoStore = createDemoStore();
 }
 
-export function getGroupRecord(groupId: string) {
-  // Return clones so route/service code cannot accidentally mutate demo state without updateGroupRecord.
-  const group = demoState.groups.get(groupId);
+export function getDemoGroup(groupId: string) {
+  // Return clones so route/service code cannot accidentally mutate demo data without updateDemoGroup.
+  const group = demoStore.groups.get(groupId);
   return group ? structuredClone(group) : undefined;
 }
 
-export function getGroupPantry(groupId: string) {
-  return structuredClone(demoState.pantriesByGroup.get(groupId) ?? []);
+export function getPantry(groupId: string) {
+  return structuredClone(
+    demoStore.pantryByGroup.get(groupId) ?? []
+  );
 }
 
-export function getBundleTemplates(groupId: string) {
-  return structuredClone(demoState.bundleTemplatesByGroup.get(groupId) ?? []);
+export function getBundles(groupId: string) {
+  return structuredClone(
+    demoStore.bundlesByGroup.get(groupId) ?? []
+  );
 }
 
-export function getIngredientCatalog() {
-  return structuredClone(INGREDIENT_CATALOG);
+export function getIngredientOptions() {
+  return structuredClone(INGREDIENTS);
 }
 
-export function getDefaultStaplesPreset() {
-  return INGREDIENT_CATALOG.filter((item) => DEFAULT_STAPLES_PRESET_IDS.includes(item.id));
+export function getDefaultStaples() {
+  return INGREDIENTS.filter((item) =>
+    DEFAULT_STAPLE_IDS.includes(item.id)
+  );
 }
 
-export function resolveIngredientIds(ids: string[]) {
-  const idSet = new Set(ids);
-  return INGREDIENT_CATALOG.filter((item) => idSet.has(item.id));
+export function getIngredientsById(ids: string[]) {
+  const requestedIds = new Set(ids);
+  return INGREDIENTS.filter((item) =>
+    requestedIds.has(item.id)
+  );
 }
 
-export function updateGroupRecord(
+export function updateDemoGroup(
   groupId: string,
-  updates: Partial<Pick<GroupRecord, "allowMissingIngredients" | "staplesEnabled" | "customStaples">>,
+  updates: Partial<
+    Pick<
+      DemoGroup,
+      | 'allowMissingIngredients'
+      | 'staplesEnabled'
+      | 'customStaples'
+    >
+  >
 ) {
-  const group = demoState.groups.get(groupId);
+  const group = demoStore.groups.get(groupId);
 
   if (!group) {
     return undefined;
   }
 
-  if (typeof updates.allowMissingIngredients === "boolean") {
-    group.allowMissingIngredients = updates.allowMissingIngredients;
+  if (typeof updates.allowMissingIngredients === 'boolean') {
+    group.allowMissingIngredients =
+      updates.allowMissingIngredients;
   }
 
-  if (typeof updates.staplesEnabled === "boolean") {
+  if (typeof updates.staplesEnabled === 'boolean') {
     group.staplesEnabled = updates.staplesEnabled;
   }
 

--- a/packages/backend/src/lib/group-service.ts
+++ b/packages/backend/src/lib/group-service.ts
@@ -1,19 +1,19 @@
-import { ApiError } from "./api-error";
+import { ApiError } from './api-error';
 import {
-  getDefaultStaplesPreset,
-  getIngredientCatalog,
-  getBundleTemplates,
-  getGroupPantry,
-  getGroupRecord,
-  resolveIngredientIds,
+  getDefaultStaples,
+  getIngredientOptions,
+  getBundles,
+  getPantry,
+  getDemoGroup,
+  getIngredientsById,
   type GroupRole,
-  updateGroupRecord,
-} from "./demo-store";
-import { buildValidatedCandidateSet } from "./bundle-validator";
+  updateDemoGroup
+} from './demo-store';
+import { buildCandidateList } from './bundle-validator';
 
 // The group service owns US7/US8 demo behavior: settings reads/writes plus
 // candidate filtering that depends on missing-ingredient and staples settings.
-type ViewerContext = {
+type GroupView = {
   groupId: string;
   groupName: string;
   allowMissingIngredients: boolean;
@@ -25,17 +25,20 @@ type ViewerContext = {
   viewerRole: GroupRole;
 };
 
-type GroupSettingsUpdate = {
+type SettingsPatch = {
   allowMissingIngredients?: boolean;
   staplesEnabled?: boolean;
   customStaples?: string[];
 };
 
-function buildSettingsPayload(groupId: string, viewerRole: GroupRole) {
-  const group = getGroupRecord(groupId);
+function formatSettings(
+  groupId: string,
+  viewerRole: GroupRole
+) {
+  const group = getDemoGroup(groupId);
 
   if (!group) {
-    throw new ApiError(404, "Group not found.");
+    throw new ApiError(404, 'Group not found.');
   }
 
   return {
@@ -43,25 +46,33 @@ function buildSettingsPayload(groupId: string, viewerRole: GroupRole) {
     groupName: group.name,
     allowMissingIngredients: group.allowMissingIngredients,
     staplesEnabled: group.staplesEnabled,
-    defaultStaplesPreset: getDefaultStaplesPreset(),
-    customStaples: resolveIngredientIds(group.customStaples),
-    ingredientCatalog: getIngredientCatalog(),
+    defaultStaplesPreset: getDefaultStaples(),
+    customStaples: getIngredientsById(group.customStaples),
+    ingredientCatalog: getIngredientOptions(),
     updatedAt: group.updatedAt,
-    viewerRole,
+    viewerRole
   };
 }
 
-function getViewerContext(groupId: string, userId: string): ViewerContext {
-  const group = getGroupRecord(groupId);
+function getGroupView(
+  groupId: string,
+  userId: string
+): GroupView {
+  const group = getDemoGroup(groupId);
 
   if (!group) {
-    throw new ApiError(404, "Group not found.");
+    throw new ApiError(404, 'Group not found.');
   }
 
-  const membership = group.members.find((member) => member.userId === userId);
+  const membership = group.members.find(
+    (member) => member.userId === userId
+  );
 
   if (!membership) {
-    throw new ApiError(403, "You must belong to the group to access its settings.");
+    throw new ApiError(
+      403,
+      'You must belong to the group to access its settings.'
+    );
   }
 
   // Every settings response includes viewerRole so the frontend can hide admin-only controls.
@@ -70,57 +81,81 @@ function getViewerContext(groupId: string, userId: string): ViewerContext {
     groupName: group.name,
     allowMissingIngredients: group.allowMissingIngredients,
     staplesEnabled: group.staplesEnabled,
-    defaultStaplesPreset: getDefaultStaplesPreset(),
-    customStaples: resolveIngredientIds(group.customStaples),
-    ingredientCatalog: getIngredientCatalog(),
+    defaultStaplesPreset: getDefaultStaples(),
+    customStaples: getIngredientsById(group.customStaples),
+    ingredientCatalog: getIngredientOptions(),
     updatedAt: group.updatedAt,
-    viewerRole: membership.role,
+    viewerRole: membership.role
   };
 }
 
-export function readGroupSettings(groupId: string, userId: string) {
-  return getViewerContext(groupId, userId);
+export function getGroupSettings(
+  groupId: string,
+  userId: string
+) {
+  return getGroupView(groupId, userId);
 }
 
-export function saveGroupSettings(groupId: string, userId: string, updates: GroupSettingsUpdate) {
-  const context = getViewerContext(groupId, userId);
+export function updateGroupSettings(
+  groupId: string,
+  userId: string,
+  updates: SettingsPatch
+) {
+  const view = getGroupView(groupId, userId);
 
-  if (context.viewerRole !== "admin") {
-    throw new ApiError(403, "Only admins can update group settings.");
+  if (view.viewerRole !== 'admin') {
+    throw new ApiError(
+      403,
+      'Only admins can update group settings.'
+    );
   }
 
   if (updates.customStaples) {
-    const validIds = new Set(getIngredientCatalog().map((item) => item.id));
-    const invalidStaple = updates.customStaples.find((id) => !validIds.has(id));
+    const ingredientIds = new Set(
+      getIngredientOptions().map((item) => item.id)
+    );
+    const unknownStaple = updates.customStaples.find(
+      (id) => !ingredientIds.has(id)
+    );
 
-    if (invalidStaple) {
-      throw new ApiError(400, `Unknown staple ingredient id: ${invalidStaple}.`);
+    if (unknownStaple) {
+      throw new ApiError(
+        400,
+        `Unknown staple ingredient id: ${unknownStaple}.`
+      );
     }
   }
 
-  const updatedGroup = updateGroupRecord(groupId, updates);
-
-  if (!updatedGroup) {
-    throw new ApiError(404, "Group not found.");
-  }
-
-  return buildSettingsPayload(updatedGroup.id, context.viewerRole);
-}
-
-export function readBundleCandidates(groupId: string, userId: string) {
-  const context = getViewerContext(groupId, userId);
-  const group = getGroupRecord(groupId);
+  const group = updateDemoGroup(groupId, updates);
 
   if (!group) {
-    throw new ApiError(404, "Group not found.");
+    throw new ApiError(404, 'Group not found.');
   }
 
-  // Validation happens after loading pantry and templates so the response can include
+  return formatSettings(group.id, view.viewerRole);
+}
+
+export function getBundleCandidates(
+  groupId: string,
+  userId: string
+) {
+  const view = getGroupView(groupId, userId);
+  const group = getDemoGroup(groupId);
+
+  if (!group) {
+    throw new ApiError(404, 'Group not found.');
+  }
+
+  // Validation happens after loading pantry and bundles so the response can include
   // both visible candidates and the number filtered out by group policy.
-  const candidateSet = buildValidatedCandidateSet(group, getBundleTemplates(groupId), getGroupPantry(groupId));
+  const candidateList = buildCandidateList(
+    group,
+    getBundles(groupId),
+    getPantry(groupId)
+  );
 
   return {
-    ...context,
-    ...candidateSet,
+    ...view,
+    ...candidateList
   };
 }

--- a/packages/backend/src/lib/ingredient-service.test.ts
+++ b/packages/backend/src/lib/ingredient-service.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  addPantryItem,
+  listIngredientOptions,
+  listPantryItems,
+  updatePantryItem
+} from './ingredient-service';
+
+const prismaMock = vi.hoisted(() => ({
+  profile: {
+    findUnique: vi.fn()
+  },
+  ingredientCatalog: {
+    findMany: vi.fn(),
+    findUnique: vi.fn()
+  },
+  pantryItem: {
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn()
+  }
+}));
+
+vi.mock('./prisma', () => ({
+  prisma: prismaMock
+}));
+
+const OWNER_ID = '00000000-0000-4000-8000-000000000001';
+const PANTRY_ITEM_ID = '00000000-0000-4000-8000-000000000002';
+const TOMATO_ID = '00000000-0000-4000-8000-000000000003';
+const OTHER_TOMATO_ID = '00000000-0000-4000-8000-000000000004';
+const NOW = new Date('2026-05-15T12:00:00.000Z');
+
+function ingredientOption(overrides = {}) {
+  return {
+    id: TOMATO_ID,
+    name: 'Tomatoes',
+    category: 'produce',
+    defaultUnit: 'whole',
+    allowedUnits: ['whole', 'cups', 'grams'],
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides
+  };
+}
+
+function pantryItem(overrides = {}) {
+  return {
+    id: PANTRY_ITEM_ID,
+    ownerId: OWNER_ID,
+    ingredientCatalogId: TOMATO_ID,
+    quantity: 4,
+    unit: 'whole',
+    notes: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ingredient: ingredientOption(),
+    ...overrides
+  };
+}
+
+describe('ingredient service catalog-backed pantry items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists canonical catalog choices with optional search', async () => {
+    prismaMock.ingredientCatalog.findMany.mockResolvedValue([
+      ingredientOption()
+    ]);
+
+    await expect(
+      listIngredientOptions('tom')
+    ).resolves.toMatchObject([
+      {
+        id: TOMATO_ID,
+        name: 'Tomatoes',
+        defaultUnit: 'whole',
+        allowedUnits: ['whole', 'cups', 'grams'],
+        createdAt: NOW.toISOString(),
+        updatedAt: NOW.toISOString()
+      }
+    ]);
+
+    expect(
+      prismaMock.ingredientCatalog.findMany
+    ).toHaveBeenCalledWith({
+      where: {
+        name: {
+          contains: 'tom',
+          mode: 'insensitive'
+        }
+      },
+      orderBy: { name: 'asc' }
+    });
+  });
+
+  it('lists pantry rows joined to their catalog ingredient', async () => {
+    prismaMock.pantryItem.findMany.mockResolvedValue([
+      pantryItem()
+    ]);
+
+    await expect(listPantryItems(OWNER_ID)).resolves.toEqual([
+      {
+        id: PANTRY_ITEM_ID,
+        ownerId: OWNER_ID,
+        ingredientCatalogId: TOMATO_ID,
+        name: 'Tomatoes',
+        ingredient: {
+          id: TOMATO_ID,
+          name: 'Tomatoes',
+          category: 'produce',
+          defaultUnit: 'whole',
+          allowedUnits: ['whole', 'cups', 'grams'],
+          createdAt: NOW.toISOString(),
+          updatedAt: NOW.toISOString()
+        },
+        quantity: 4,
+        unit: 'whole',
+        notes: null,
+        createdAt: NOW.toISOString(),
+        updatedAt: NOW.toISOString()
+      }
+    ]);
+
+    expect(prismaMock.pantryItem.findMany).toHaveBeenCalledWith(
+      {
+        where: { ownerId: OWNER_ID },
+        include: { ingredient: true },
+        orderBy: [
+          { ingredient: { name: 'asc' } },
+          { createdAt: 'asc' }
+        ]
+      }
+    );
+  });
+
+  it('creates a pantry item only when the unit is allowed by the catalog row', async () => {
+    prismaMock.profile.findUnique.mockResolvedValue({
+      id: OWNER_ID
+    });
+    prismaMock.ingredientCatalog.findUnique.mockResolvedValue(
+      ingredientOption()
+    );
+    prismaMock.pantryItem.create.mockResolvedValue(
+      pantryItem()
+    );
+
+    await expect(
+      addPantryItem(OWNER_ID, {
+        ingredientCatalogId: TOMATO_ID,
+        quantity: 4,
+        unit: 'whole'
+      })
+    ).resolves.toMatchObject({
+      id: PANTRY_ITEM_ID,
+      name: 'Tomatoes',
+      quantity: 4,
+      unit: 'whole'
+    });
+
+    expect(prismaMock.pantryItem.create).toHaveBeenCalledWith({
+      data: {
+        ownerId: OWNER_ID,
+        ingredientCatalogId: TOMATO_ID,
+        quantity: 4,
+        unit: 'whole',
+        notes: undefined
+      },
+      include: { ingredient: true }
+    });
+  });
+
+  it('rejects a pantry item unit that does not belong to the selected ingredient', async () => {
+    prismaMock.profile.findUnique.mockResolvedValue({
+      id: OWNER_ID
+    });
+    prismaMock.ingredientCatalog.findUnique.mockResolvedValue(
+      ingredientOption()
+    );
+
+    await expect(
+      addPantryItem(OWNER_ID, {
+        ingredientCatalogId: TOMATO_ID,
+        quantity: 4,
+        unit: 'bottles'
+      })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'bottles is not an allowed unit for Tomatoes.'
+    });
+
+    expect(prismaMock.pantryItem.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects blank required quantities instead of coercing them to zero', async () => {
+    prismaMock.profile.findUnique.mockResolvedValue({
+      id: OWNER_ID
+    });
+    prismaMock.ingredientCatalog.findUnique.mockResolvedValue(
+      ingredientOption()
+    );
+
+    await expect(
+      addPantryItem(OWNER_ID, {
+        ingredientCatalogId: TOMATO_ID,
+        quantity: '   ',
+        unit: 'whole'
+      })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'quantity must be a non-negative number.'
+    });
+
+    expect(prismaMock.pantryItem.create).not.toHaveBeenCalled();
+  });
+
+  it('validates the final ingredient and unit pair before updating a pantry item', async () => {
+    prismaMock.pantryItem.findFirst.mockResolvedValue(
+      pantryItem()
+    );
+    prismaMock.ingredientCatalog.findUnique.mockResolvedValue(
+      ingredientOption({
+        id: OTHER_TOMATO_ID,
+        name: 'Olive oil',
+        defaultUnit: 'tbsp',
+        allowedUnits: ['tbsp', 'tsp', 'ml']
+      })
+    );
+
+    await expect(
+      updatePantryItem(OWNER_ID, PANTRY_ITEM_ID, {
+        ingredientCatalogId: OTHER_TOMATO_ID
+      })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'whole is not an allowed unit for Olive oil.'
+    });
+
+    expect(prismaMock.pantryItem.update).not.toHaveBeenCalled();
+  });
+
+  it('returns the updated pantry item with its catalog data', async () => {
+    prismaMock.pantryItem.findFirst.mockResolvedValue(
+      pantryItem()
+    );
+    prismaMock.pantryItem.update.mockResolvedValue(
+      pantryItem({ quantity: 6 })
+    );
+
+    await expect(
+      updatePantryItem(OWNER_ID, PANTRY_ITEM_ID, {
+        quantity: 6
+      })
+    ).resolves.toMatchObject({
+      id: PANTRY_ITEM_ID,
+      name: 'Tomatoes',
+      quantity: 6,
+      ingredient: {
+        id: TOMATO_ID,
+        allowedUnits: ['whole', 'cups', 'grams']
+      }
+    });
+  });
+});

--- a/packages/backend/src/lib/ingredient-service.ts
+++ b/packages/backend/src/lib/ingredient-service.ts
@@ -1,119 +1,272 @@
-import type { Ingredient } from '../generated/prisma';
-import { ApiError } from './api-error';
+import type {
+  IngredientCatalog,
+  PantryItem
+} from '../generated/prisma';
+import { ApiError, isPrismaError } from './api-error';
 import { prisma } from './prisma';
 import { assertUuid } from './request-user';
 
-// Ingredient service currently models each user's pantry items.
-// The ownerId argument is always supplied by the route from x-user-id, never trusted from request JSON.
-type IngredientCreateInput = {
-  name?: unknown;
+// The ownerId argument always comes from x-user-id, never from request JSON.
+type PantryRequestBody = {
+  ingredientCatalogId?: unknown;
   quantity?: unknown;
   unit?: unknown;
   notes?: unknown;
 };
 
-type IngredientUpdateInput = Partial<IngredientCreateInput>;
+type PantryPatchBody = Partial<PantryRequestBody>;
 
-function isPrismaError(error: unknown, code: string) {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    error.code === code
+type NewPantryItem = {
+  ingredientCatalogId: string;
+  quantity: number;
+  unit: string;
+  notes?: string | null;
+};
+
+type PantryPatch = Partial<NewPantryItem>;
+
+type PantryRow = PantryItem & {
+  ingredient: IngredientCatalog;
+};
+
+export async function listIngredientOptions(search?: string) {
+  const searchTerm = search?.trim();
+  const options = await prisma.ingredientCatalog.findMany({
+    where: searchTerm
+      ? {
+          name: {
+            contains: searchTerm,
+            mode: 'insensitive'
+          }
+        }
+      : {},
+    orderBy: { name: 'asc' }
+  });
+
+  return options.map(formatIngredientOption);
+}
+
+export async function listPantryItems(ownerId: string) {
+  assertUuid(ownerId, 'ownerId');
+
+  const pantryItems = await prisma.pantryItem.findMany({
+    where: { ownerId },
+    include: { ingredient: true },
+    orderBy: [
+      { ingredient: { name: 'asc' } },
+      { createdAt: 'asc' }
+    ]
+  });
+
+  return pantryItems.map(formatPantryItem);
+}
+
+export async function addPantryItem(
+  ownerId: string,
+  input: PantryRequestBody
+) {
+  assertUuid(ownerId, 'ownerId');
+  await requireProfile(ownerId);
+
+  const fields = readPantryFields(input, 'create');
+  const catalogItem = await getCatalogItem(
+    fields.ingredientCatalogId
   );
+  requireAllowedUnit(catalogItem, fields.unit);
+
+  try {
+    const pantryItem = await prisma.pantryItem.create({
+      data: {
+        ownerId,
+        ...fields
+      },
+      include: { ingredient: true }
+    });
+
+    return formatPantryItem(pantryItem);
+  } catch (error) {
+    if (isPrismaError(error, 'P2002')) {
+      throw new ApiError(
+        409,
+        'You already have that ingredient with that unit.'
+      );
+    }
+
+    throw error;
+  }
 }
 
-function normalizeRequiredText(
-  value: unknown,
-  fieldName: string,
-  maxLength: number
+export async function updatePantryItem(
+  ownerId: string,
+  pantryItemId: string,
+  input: PantryPatchBody
 ) {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new ApiError(400, `${fieldName} is required.`);
+  assertUuid(ownerId, 'ownerId');
+  assertUuid(pantryItemId, 'ingredientId');
+
+  const fields = readPantryFields(input, 'update');
+  const pantryItem = await prisma.pantryItem.findFirst({
+    where: { id: pantryItemId, ownerId },
+    include: { ingredient: true }
+  });
+
+  if (!pantryItem) {
+    throw new ApiError(404, 'Pantry item not found.');
   }
 
-  const trimmed = value.trim();
+  const catalogItem =
+    fields.ingredientCatalogId !== undefined
+      ? await getCatalogItem(fields.ingredientCatalogId)
+      : pantryItem.ingredient;
+  requireAllowedUnit(
+    catalogItem,
+    fields.unit ?? pantryItem.unit
+  );
 
-  if (trimmed.length > maxLength) {
-    throw new ApiError(
-      400,
-      `${fieldName} must be ${maxLength} characters or fewer.`
-    );
+  try {
+    const updatedItem = await prisma.pantryItem.update({
+      where: { id: pantryItemId },
+      data: fields,
+      include: { ingredient: true }
+    });
+
+    return formatPantryItem(updatedItem);
+  } catch (error) {
+    if (isPrismaError(error, 'P2002')) {
+      throw new ApiError(
+        409,
+        'You already have that ingredient with that unit.'
+      );
+    }
+
+    throw error;
   }
-
-  return trimmed;
 }
 
-function normalizeNullableText(
-  value: unknown,
-  fieldName: string,
-  maxLength: number
+export async function deletePantryItem(
+  ownerId: string,
+  pantryItemId: string
 ) {
-  if (value === undefined) {
-    return undefined;
+  assertUuid(ownerId, 'ownerId');
+  assertUuid(pantryItemId, 'ingredientId');
+
+  const result = await prisma.pantryItem.deleteMany({
+    where: { id: pantryItemId, ownerId }
+  });
+
+  if (result.count === 0) {
+    throw new ApiError(404, 'Pantry item not found.');
+  }
+}
+
+function readPantryFields(
+  input: PantryRequestBody,
+  mode: 'create'
+): NewPantryItem;
+function readPantryFields(
+  input: PantryPatchBody,
+  mode: 'update'
+): PantryPatch;
+function readPantryFields(
+  input: PantryRequestBody,
+  mode: 'create' | 'update'
+) {
+  const isUpdate = mode === 'update';
+  const fields: PantryPatch = {};
+  const shouldRead = (field: keyof PantryRequestBody) =>
+    !isUpdate || input[field] !== undefined;
+
+  if (shouldRead('ingredientCatalogId')) {
+    if (
+      typeof input.ingredientCatalogId !== 'string' ||
+      input.ingredientCatalogId.trim().length === 0
+    ) {
+      throw new ApiError(
+        400,
+        'ingredientCatalogId is required.'
+      );
+    }
+
+    const ingredientCatalogId =
+      input.ingredientCatalogId.trim();
+    assertUuid(ingredientCatalogId, 'ingredientCatalogId');
+    fields.ingredientCatalogId = ingredientCatalogId;
   }
 
-  if (value === null) {
-    return null;
+  if (shouldRead('quantity')) {
+    if (
+      typeof input.quantity !== 'number' ||
+      !Number.isFinite(input.quantity) ||
+      input.quantity < 0
+    ) {
+      throw new ApiError(
+        400,
+        'quantity must be a non-negative number.'
+      );
+    }
+
+    fields.quantity = input.quantity;
   }
 
-  if (typeof value !== 'string') {
-    throw new ApiError(400, `${fieldName} must be a string.`);
+  if (shouldRead('unit')) {
+    if (
+      typeof input.unit !== 'string' ||
+      input.unit.trim().length === 0
+    ) {
+      throw new ApiError(400, 'unit is required.');
+    }
+
+    fields.unit = input.unit.trim();
   }
 
-  const trimmed = value.trim();
+  if (input.notes !== undefined) {
+    if (input.notes === null) {
+      fields.notes = null;
+    } else if (typeof input.notes !== 'string') {
+      throw new ApiError(400, 'notes must be a string.');
+    } else {
+      fields.notes = input.notes.trim() || null;
+    }
+  }
 
-  if (trimmed.length > maxLength) {
+  if (isUpdate && Object.keys(fields).length === 0) {
     throw new ApiError(
       400,
-      `${fieldName} must be ${maxLength} characters or fewer.`
+      'No supported ingredient fields were provided.'
     );
   }
 
-  return trimmed || null;
+  return fields;
 }
 
-function normalizeNullableQuantity(value: unknown) {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (value === null || value === '') {
-    return null;
-  }
-
-  const quantity =
-    typeof value === 'number' ? value : Number(value);
-
-  if (!Number.isFinite(quantity) || quantity < 0) {
-    throw new ApiError(
-      400,
-      'quantity must be a non-negative number.'
-    );
-  }
-
-  return quantity;
-}
-
-function serializeIngredient(ingredient: Ingredient) {
-  // Prisma decimals serialize awkwardly; convert them before returning API JSON.
+function formatIngredientOption(option: IngredientCatalog) {
   return {
-    id: ingredient.id,
-    ownerId: ingredient.ownerId,
-    name: ingredient.name,
-    quantity:
-      ingredient.quantity === null
-        ? null
-        : Number(ingredient.quantity),
-    unit: ingredient.unit,
-    notes: ingredient.notes,
-    createdAt: ingredient.createdAt.toISOString(),
-    updatedAt: ingredient.updatedAt.toISOString()
+    id: option.id,
+    name: option.name,
+    category: option.category,
+    defaultUnit: option.defaultUnit,
+    allowedUnits: option.allowedUnits,
+    createdAt: option.createdAt.toISOString(),
+    updatedAt: option.updatedAt.toISOString()
   };
 }
 
-async function ensureProfileExists(ownerId: string) {
-  // Fail with a clear 404 before relying on a database foreign-key error.
+function formatPantryItem(pantryItem: PantryRow) {
+  return {
+    id: pantryItem.id,
+    ownerId: pantryItem.ownerId,
+    ingredientCatalogId: pantryItem.ingredientCatalogId,
+    name: pantryItem.ingredient.name,
+    ingredient: formatIngredientOption(pantryItem.ingredient),
+    quantity: Number(pantryItem.quantity),
+    unit: pantryItem.unit,
+    notes: pantryItem.notes,
+    createdAt: pantryItem.createdAt.toISOString(),
+    updatedAt: pantryItem.updatedAt.toISOString()
+  };
+}
+
+async function requireProfile(ownerId: string) {
   const profile = await prisma.profile.findUnique({
     where: { id: ownerId },
     select: { id: true }
@@ -124,129 +277,28 @@ async function ensureProfileExists(ownerId: string) {
   }
 }
 
-export async function listIngredients(ownerId: string) {
-  assertUuid(ownerId, 'ownerId');
-
-  const ingredients = await prisma.ingredient.findMany({
-    where: { ownerId },
-    orderBy: [{ name: 'asc' }, { createdAt: 'asc' }]
-  });
-
-  return ingredients.map(serializeIngredient);
-}
-
-export async function createIngredient(
-  ownerId: string,
-  input: IngredientCreateInput
-) {
-  assertUuid(ownerId, 'ownerId');
-  await ensureProfileExists(ownerId);
-
-  try {
-    const ingredient = await prisma.ingredient.create({
-      data: {
-        ownerId,
-        name: normalizeRequiredText(input.name, 'name', 120),
-        quantity: normalizeNullableQuantity(input.quantity),
-        unit: normalizeNullableText(input.unit, 'unit', 40),
-        notes: normalizeNullableText(
-          input.notes,
-          'notes',
-          2_000
-        )
-      }
-    });
-
-    return serializeIngredient(ingredient);
-  } catch (error) {
-    if (isPrismaError(error, 'P2002')) {
-      // P2002 maps to @@unique([ownerId, name]) in schema.prisma.
-      throw new ApiError(
-        409,
-        'You already have an ingredient with that name.'
-      );
+async function getCatalogItem(ingredientCatalogId: string) {
+  const catalogItem = await prisma.ingredientCatalog.findUnique(
+    {
+      where: { id: ingredientCatalogId }
     }
+  );
 
-    throw error;
+  if (!catalogItem) {
+    throw new ApiError(400, 'Unknown ingredientCatalogId.');
   }
+
+  return catalogItem;
 }
 
-export async function updateIngredient(
-  ownerId: string,
-  ingredientId: string,
-  input: IngredientUpdateInput
+function requireAllowedUnit(
+  catalogItem: IngredientCatalog,
+  unit: string
 ) {
-  assertUuid(ownerId, 'ownerId');
-  assertUuid(ingredientId, 'ingredientId');
-
-  const data = {
-    ...(input.name !== undefined
-      ? { name: normalizeRequiredText(input.name, 'name', 120) }
-      : {}),
-    ...(input.quantity !== undefined
-      ? { quantity: normalizeNullableQuantity(input.quantity) }
-      : {}),
-    ...(input.unit !== undefined
-      ? { unit: normalizeNullableText(input.unit, 'unit', 40) }
-      : {}),
-    ...(input.notes !== undefined
-      ? {
-          notes: normalizeNullableText(
-            input.notes,
-            'notes',
-            2_000
-          )
-        }
-      : {})
-  };
-
-  if (Object.keys(data).length === 0) {
+  if (!catalogItem.allowedUnits.includes(unit)) {
     throw new ApiError(
       400,
-      'No supported ingredient fields were provided.'
+      `${unit} is not an allowed unit for ${catalogItem.name}.`
     );
-  }
-
-  const existingIngredient = await prisma.ingredient.findFirst({
-    where: { id: ingredientId, ownerId },
-    select: { id: true }
-  });
-
-  if (!existingIngredient) {
-    throw new ApiError(404, 'Ingredient not found.');
-  }
-
-  try {
-    const ingredient = await prisma.ingredient.update({
-      where: { id: ingredientId },
-      data
-    });
-
-    return serializeIngredient(ingredient);
-  } catch (error) {
-    if (isPrismaError(error, 'P2002')) {
-      throw new ApiError(
-        409,
-        'You already have an ingredient with that name.'
-      );
-    }
-
-    throw error;
-  }
-}
-
-export async function deleteIngredient(
-  ownerId: string,
-  ingredientId: string
-) {
-  assertUuid(ownerId, 'ownerId');
-  assertUuid(ingredientId, 'ingredientId');
-
-  const result = await prisma.ingredient.deleteMany({
-    where: { id: ingredientId, ownerId }
-  });
-
-  if (result.count === 0) {
-    throw new ApiError(404, 'Ingredient not found.');
   }
 }

--- a/packages/backend/src/lib/profile-service.ts
+++ b/packages/backend/src/lib/profile-service.ts
@@ -1,28 +1,91 @@
 import type { Profile } from '../generated/prisma';
-import { ApiError } from './api-error';
+import { ApiError, isPrismaError } from './api-error';
 import { prisma } from './prisma';
 import { assertUuid } from './request-user';
 
-// Profile service = user persistence for the SRD's sign-in/session story.
-// Routes stay thin by delegating validation, Prisma calls, and serialization here.
-type ProfileCreateInput = {
+type ProfileRequestBody = {
   id?: unknown;
   email?: unknown;
   displayName?: unknown;
 };
 
+type NewProfile = {
+  id?: string;
+  email: string;
+  displayName?: string;
+};
+
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function isPrismaError(error: unknown, code: string) {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    error.code === code
-  );
+export async function createProfile(input: ProfileRequestBody) {
+  const fields = readNewProfile(input);
+
+  try {
+    const profile = await prisma.profile.create({
+      data: fields
+    });
+
+    return formatProfile(profile);
+  } catch (error) {
+    if (isPrismaError(error, 'P2002')) {
+      throw new ApiError(
+        409,
+        'A profile with that email already exists.'
+      );
+    }
+
+    throw error;
+  }
 }
 
-function normalizeOptionalText(
+export async function getProfile(profileId: string) {
+  assertUuid(profileId, 'profileId');
+
+  const profile = await prisma.profile.findUnique({
+    where: { id: profileId }
+  });
+
+  if (!profile) {
+    throw new ApiError(404, 'Profile not found.');
+  }
+
+  return formatProfile(profile);
+}
+
+function readNewProfile(input: ProfileRequestBody): NewProfile {
+  if (
+    typeof input.email !== 'string' ||
+    !EMAIL_REGEX.test(input.email.trim())
+  ) {
+    throw new ApiError(
+      400,
+      'email must be a valid email address.'
+    );
+  }
+
+  const fields: NewProfile = {
+    email: input.email.trim().toLowerCase()
+  };
+  const id = readOptionalText(input.id, 'id', 36);
+  const displayName = readOptionalText(
+    input.displayName,
+    'displayName',
+    120
+  );
+
+  if (id) {
+    assertUuid(id, 'id');
+    fields.id = id;
+  }
+
+  if (displayName) {
+    fields.displayName = displayName;
+  }
+
+  return fields;
+}
+
+function readOptionalText(
   value: unknown,
   fieldName: string,
   maxLength: number
@@ -35,20 +98,18 @@ function normalizeOptionalText(
     throw new ApiError(400, `${fieldName} must be a string.`);
   }
 
-  const trimmed = value.trim();
-
-  if (trimmed.length > maxLength) {
+  const text = value.trim();
+  if (text.length > maxLength) {
     throw new ApiError(
       400,
       `${fieldName} must be ${maxLength} characters or fewer.`
     );
   }
 
-  return trimmed || undefined;
+  return text || undefined;
 }
 
-function serializeProfile(profile: Profile) {
-  // Convert Date objects to ISO strings so API responses are plain JSON.
+function formatProfile(profile: Profile) {
   return {
     id: profile.id,
     email: profile.email,
@@ -56,62 +117,4 @@ function serializeProfile(profile: Profile) {
     createdAt: profile.createdAt.toISOString(),
     updatedAt: profile.updatedAt.toISOString()
   };
-}
-
-export async function createProfile(input: ProfileCreateInput) {
-  if (
-    typeof input.email !== 'string' ||
-    !EMAIL_REGEX.test(input.email.trim())
-  ) {
-    throw new ApiError(
-      400,
-      'email must be a valid email address.'
-    );
-  }
-
-  const id = normalizeOptionalText(input.id, 'id', 36);
-
-  if (id) {
-    assertUuid(id, 'id');
-  }
-
-  try {
-    const profile = await prisma.profile.create({
-      data: {
-        ...(id ? { id } : {}),
-        email: input.email.trim().toLowerCase(),
-        displayName: normalizeOptionalText(
-          input.displayName,
-          'displayName',
-          120
-        )
-      }
-    });
-
-    return serializeProfile(profile);
-  } catch (error) {
-    if (isPrismaError(error, 'P2002')) {
-      // P2002 is Prisma's unique-constraint error; here it means duplicate email.
-      throw new ApiError(
-        409,
-        'A profile with that email already exists.'
-      );
-    }
-
-    throw error;
-  }
-}
-
-export async function readProfile(profileId: string) {
-  assertUuid(profileId, 'profileId');
-
-  const profile = await prisma.profile.findUnique({
-    where: { id: profileId }
-  });
-
-  if (!profile) {
-    throw new ApiError(404, 'Profile not found.');
-  }
-
-  return serializeProfile(profile);
 }

--- a/packages/backend/src/lib/us7.test.ts
+++ b/packages/backend/src/lib/us7.test.ts
@@ -1,119 +1,164 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { GET as getBundleCandidates } from "../app/api/groups/[groupId]/bundle-candidates/route";
-import { GET as getSettings, PATCH as patchSettings } from "../app/api/groups/[groupId]/settings/route";
-import { DEMO_ADMIN_USER_ID, DEMO_MEMBER_USER_ID, resetDemoState } from "./demo-store";
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GET as getBundleCandidates } from '../app/api/groups/[groupId]/bundle-candidates/route';
+import {
+  GET as getSettings,
+  PATCH as patchSettings
+} from '../app/api/groups/[groupId]/settings/route';
+import {
+  DEMO_ADMIN_ID,
+  DEMO_MEMBER_ID,
+  resetDemoStore
+} from './demo-store';
 
-const GROUP_ID = "dorm-dinner-crew";
+const GROUP_ID = 'dorm-dinner-crew';
 
-function createRouteContext(groupId: string) {
+function routeParams(groupId: string) {
   return { params: Promise.resolve({ groupId }) };
 }
 
-function createRequest(url: string, userId: string, init?: RequestInit) {
+function requestAs(
+  url: string,
+  userId: string,
+  init?: RequestInit
+) {
   return new Request(url, {
     headers: {
-      "content-type": "application/json",
-      "x-user-id": userId,
-      ...(init?.headers ?? {}),
+      'content-type': 'application/json',
+      'x-user-id': userId,
+      ...(init?.headers ?? {})
     },
-    ...init,
+    ...init
   });
 }
 
-describe("US7 missing ingredient settings", () => {
+describe('US7 missing ingredient settings', () => {
   beforeEach(() => {
-    resetDemoState();
+    resetDemoStore();
   });
 
-  it("reflects the current allowMissingIngredients value on load", async () => {
+  it('reflects the current allowMissingIngredients value on load', async () => {
     const response = await getSettings(
-      createRequest("http://localhost/api/groups/dorm-dinner-crew/settings", DEMO_ADMIN_USER_ID),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        'http://localhost/api/groups/dorm-dinner-crew/settings',
+        DEMO_ADMIN_ID
+      ),
+      routeParams(GROUP_ID)
     );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       groupId: GROUP_ID,
       allowMissingIngredients: false,
-      viewerRole: "admin",
+      viewerRole: 'admin'
     });
   });
 
-  it("rejects missing-ingredient candidates when the setting is disabled", async () => {
+  it('rejects missing-ingredient candidates when the setting is disabled', async () => {
     const response = await getBundleCandidates(
-      createRequest(
-        "http://localhost/api/groups/dorm-dinner-crew/bundle-candidates",
-        DEMO_ADMIN_USER_ID,
+      requestAs(
+        'http://localhost/api/groups/dorm-dinner-crew/bundle-candidates',
+        DEMO_ADMIN_ID
       ),
-      createRouteContext(GROUP_ID),
+      routeParams(GROUP_ID)
     );
 
     const payload = (await response.json()) as {
       filteredOutCandidateCount: number;
-      candidates: Array<{ id: string; missingIngredients: unknown[] }>;
+      candidates: Array<{
+        id: string;
+        missingIngredients: unknown[];
+      }>;
     };
 
     expect(response.status).toBe(200);
-    expect(payload.filteredOutCandidateCount).toBeGreaterThan(0);
-    expect(payload.candidates.some((candidate) => candidate.id === "bundle-saffron-pasta-night")).toBe(false);
-    expect(payload.candidates.every((candidate) => candidate.missingIngredients.length === 0)).toBe(true);
+    expect(payload.filteredOutCandidateCount).toBeGreaterThan(
+      0
+    );
+    expect(
+      payload.candidates.some(
+        (candidate) =>
+          candidate.id === 'bundle-saffron-pasta-night'
+      )
+    ).toBe(false);
+    expect(
+      payload.candidates.every(
+        (candidate) => candidate.missingIngredients.length === 0
+      )
+    ).toBe(true);
   });
 
-  it("returns flagged candidates with missing ingredient disclosures when the setting is enabled", async () => {
+  it('returns flagged candidates with missing ingredient disclosures when the setting is enabled', async () => {
     const updateResponse = await patchSettings(
-      createRequest("http://localhost/api/groups/dorm-dinner-crew/settings", DEMO_ADMIN_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ allowMissingIngredients: true }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        'http://localhost/api/groups/dorm-dinner-crew/settings',
+        DEMO_ADMIN_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            allowMissingIngredients: true
+          })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
     expect(updateResponse.status).toBe(200);
 
     const candidateResponse = await getBundleCandidates(
-      createRequest(
-        "http://localhost/api/groups/dorm-dinner-crew/bundle-candidates",
-        DEMO_ADMIN_USER_ID,
+      requestAs(
+        'http://localhost/api/groups/dorm-dinner-crew/bundle-candidates',
+        DEMO_ADMIN_ID
       ),
-      createRouteContext(GROUP_ID),
+      routeParams(GROUP_ID)
     );
 
     const payload = (await candidateResponse.json()) as {
       candidates: Array<{
         id: string;
-        missingIngredients: Array<{ name: string; quantityNeeded: number; unit: string }>;
+        missingIngredients: Array<{
+          name: string;
+          quantityNeeded: number;
+          unit: string;
+        }>;
       }>;
     };
 
-    const missingBundle = payload.candidates.find(
-      (candidate) => candidate.id === "bundle-saffron-pasta-night",
+    const saffronPasta = payload.candidates.find(
+      (candidate) =>
+        candidate.id === 'bundle-saffron-pasta-night'
     );
 
     expect(candidateResponse.status).toBe(200);
-    expect(missingBundle).toBeDefined();
-    expect(missingBundle?.missingIngredients).toEqual(
+    expect(saffronPasta).toBeDefined();
+    expect(saffronPasta?.missingIngredients).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: "Saffron threads",
+          name: 'Saffron threads',
           quantityNeeded: 1,
-          unit: "tbsp",
-        }),
-      ]),
+          unit: 'tbsp'
+        })
+      ])
     );
   });
 
-  it("blocks non-admin members from updating the setting", async () => {
+  it('blocks non-admin members from updating the setting', async () => {
     const response = await patchSettings(
-      createRequest("http://localhost/api/groups/dorm-dinner-crew/settings", DEMO_MEMBER_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ allowMissingIngredients: true }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        'http://localhost/api/groups/dorm-dinner-crew/settings',
+        DEMO_MEMBER_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            allowMissingIngredients: true
+          })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({
-      error: "Only admins can update group settings.",
+      error: 'Only admins can update group settings.'
     });
   });
 });

--- a/packages/backend/src/lib/us8.test.ts
+++ b/packages/backend/src/lib/us8.test.ts
@@ -1,34 +1,48 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { GET as getBundleCandidates } from "../app/api/groups/[groupId]/bundle-candidates/route";
-import { GET as getSettings, PATCH as patchSettings } from "../app/api/groups/[groupId]/settings/route";
-import { DEMO_ADMIN_USER_ID, DEMO_MEMBER_USER_ID, resetDemoState } from "./demo-store";
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GET as getBundleCandidates } from '../app/api/groups/[groupId]/bundle-candidates/route';
+import {
+  GET as getSettings,
+  PATCH as patchSettings
+} from '../app/api/groups/[groupId]/settings/route';
+import {
+  DEMO_ADMIN_ID,
+  DEMO_MEMBER_ID,
+  resetDemoStore
+} from './demo-store';
 
-const GROUP_ID = "dorm-dinner-crew";
+const GROUP_ID = 'dorm-dinner-crew';
 
-function createRouteContext(groupId: string) {
+function routeParams(groupId: string) {
   return { params: Promise.resolve({ groupId }) };
 }
 
-function createRequest(url: string, userId: string, init?: RequestInit) {
+function requestAs(
+  url: string,
+  userId: string,
+  init?: RequestInit
+) {
   return new Request(url, {
     headers: {
-      "content-type": "application/json",
-      "x-user-id": userId,
-      ...(init?.headers ?? {}),
+      'content-type': 'application/json',
+      'x-user-id': userId,
+      ...(init?.headers ?? {})
     },
-    ...init,
+    ...init
   });
 }
 
-describe("US8 staples settings", () => {
+describe('US8 staples settings', () => {
   beforeEach(() => {
-    resetDemoState();
+    resetDemoStore();
   });
 
-  it("returns the exact default staples preset", async () => {
+  it('returns the exact default staples preset', async () => {
     const response = await getSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_ADMIN_USER_ID),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_ADMIN_ID
+      ),
+      routeParams(GROUP_ID)
     );
 
     const payload = (await response.json()) as {
@@ -36,82 +50,116 @@ describe("US8 staples settings", () => {
     };
 
     expect(payload.defaultStaplesPreset).toEqual([
-      { id: "olive-oil", name: "Olive oil" },
-      { id: "butter", name: "Butter" },
-      { id: "salt", name: "Salt" },
-      { id: "pepper", name: "Pepper" },
+      { id: 'olive-oil', name: 'Olive oil' },
+      { id: 'butter', name: 'Butter' },
+      { id: 'salt', name: 'Salt' },
+      { id: 'pepper', name: 'Pepper' }
     ]);
   });
 
-  it("allows an admin to toggle staplesEnabled on and off", async () => {
+  it('allows an admin to toggle staplesEnabled on and off', async () => {
     const enableResponse = await patchSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_ADMIN_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ staplesEnabled: true }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_ADMIN_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ staplesEnabled: true })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
-    const enabledPayload = (await enableResponse.json()) as { staplesEnabled: boolean };
-    expect(enabledPayload.staplesEnabled).toBe(true);
+    const enabledSettings = (await enableResponse.json()) as {
+      staplesEnabled: boolean;
+    };
+    expect(enabledSettings.staplesEnabled).toBe(true);
 
     const disableResponse = await patchSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_ADMIN_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ staplesEnabled: false }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_ADMIN_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ staplesEnabled: false })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
-    const disabledPayload = (await disableResponse.json()) as { staplesEnabled: boolean };
-    expect(disabledPayload.staplesEnabled).toBe(false);
+    const disabledSettings = (await disableResponse.json()) as {
+      staplesEnabled: boolean;
+    };
+    expect(disabledSettings.staplesEnabled).toBe(false);
   });
 
-  it("allows an admin to add and remove custom staples", async () => {
+  it('allows an admin to add and remove custom staples', async () => {
     const addResponse = await patchSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_ADMIN_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ customStaples: ["basil-leaves", "thyme"] }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_ADMIN_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            customStaples: ['basil-leaves', 'thyme']
+          })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
-    const addPayload = (await addResponse.json()) as {
+    const addSettings = (await addResponse.json()) as {
       customStaples: Array<{ id: string; name: string }>;
     };
 
-    expect(addPayload.customStaples).toEqual([
-      { id: "basil-leaves", name: "Basil leaves" },
-      { id: "thyme", name: "Fresh thyme" },
+    expect(addSettings.customStaples).toEqual([
+      { id: 'basil-leaves', name: 'Basil leaves' },
+      { id: 'thyme', name: 'Fresh thyme' }
     ]);
 
     const removeResponse = await patchSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_ADMIN_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ customStaples: ["thyme"] }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_ADMIN_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ customStaples: ['thyme'] })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
-    const removePayload = (await removeResponse.json()) as {
+    const removeSettings = (await removeResponse.json()) as {
       customStaples: Array<{ id: string; name: string }>;
     };
 
-    expect(removePayload.customStaples).toEqual([{ id: "thyme", name: "Fresh thyme" }]);
+    expect(removeSettings.customStaples).toEqual([
+      { id: 'thyme', name: 'Fresh thyme' }
+    ]);
   });
 
-  it("treats enabled staples as unlimited and surfaces them in the rationale", async () => {
+  it('treats enabled staples as unlimited and surfaces them in the rationale', async () => {
     await patchSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_ADMIN_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ staplesEnabled: true, customStaples: ["basil-leaves"] }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_ADMIN_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            staplesEnabled: true,
+            customStaples: ['basil-leaves']
+          })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
     const response = await getBundleCandidates(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/bundle-candidates`, DEMO_ADMIN_USER_ID),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/bundle-candidates`,
+        DEMO_ADMIN_ID
+      ),
+      routeParams(GROUP_ID)
     );
 
     const payload = (await response.json()) as {
@@ -119,33 +167,51 @@ describe("US8 staples settings", () => {
         id: string;
         rationale: string;
         assumedStaples: Array<{ name: string }>;
-        contributorMapping: Record<string, Array<{ userId: string }>>;
+        contributorMapping: Record<
+          string,
+          Array<{ userId: string }>
+        >;
       }>;
     };
 
-    const gardenPasta = payload.candidates.find((candidate) => candidate.id === "bundle-garden-pasta-board");
-    const bruschetta = payload.candidates.find((candidate) => candidate.id === "bundle-bruschetta-board");
+    const gardenPasta = payload.candidates.find(
+      (candidate) =>
+        candidate.id === 'bundle-garden-pasta-board'
+    );
+    const bruschetta = payload.candidates.find(
+      (candidate) => candidate.id === 'bundle-bruschetta-board'
+    );
 
     expect(gardenPasta).toBeDefined();
-    expect(gardenPasta?.assumedStaples.map((item) => item.name)).toEqual(
-      expect.arrayContaining(["Olive oil", "Salt"]),
-    );
-    expect(gardenPasta?.contributorMapping["olive-oil"]).toEqual([
-      expect.objectContaining({ userId: "group-staples" }),
+    expect(
+      gardenPasta?.assumedStaples.map((item) => item.name)
+    ).toEqual(expect.arrayContaining(['Olive oil', 'Salt']));
+    expect(
+      gardenPasta?.contributorMapping['olive-oil']
+    ).toEqual([
+      expect.objectContaining({ userId: 'group-staples' })
     ]);
-    expect(gardenPasta?.rationale).toContain("Assumed staples: Olive oil, Salt.");
+    expect(gardenPasta?.rationale).toContain(
+      'Assumed staples: Olive oil, Salt.'
+    );
 
     expect(bruschetta).toBeDefined();
-    expect(bruschetta?.assumedStaples.map((item) => item.name)).toContain("Basil leaves");
+    expect(
+      bruschetta?.assumedStaples.map((item) => item.name)
+    ).toContain('Basil leaves');
   });
 
-  it("prevents non-admin members from modifying staples settings", async () => {
+  it('prevents non-admin members from modifying staples settings', async () => {
     const response = await patchSettings(
-      createRequest(`http://localhost/api/groups/${GROUP_ID}/settings`, DEMO_MEMBER_USER_ID, {
-        method: "PATCH",
-        body: JSON.stringify({ staplesEnabled: true }),
-      }),
-      createRouteContext(GROUP_ID),
+      requestAs(
+        `http://localhost/api/groups/${GROUP_ID}/settings`,
+        DEMO_MEMBER_ID,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ staplesEnabled: true })
+        }
+      ),
+      routeParams(GROUP_ID)
     );
 
     expect(response.status).toBe(403);

--- a/prisma/migrations/20260515190000_split_ingredient_catalog_and_pantry_items/migration.sql
+++ b/prisma/migrations/20260515190000_split_ingredient_catalog_and_pantry_items/migration.sql
@@ -1,0 +1,121 @@
+-- CreateTable
+CREATE TABLE "ingredient_catalog" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" VARCHAR(120) NOT NULL,
+    "category" VARCHAR(80),
+    "default_unit" VARCHAR(40) NOT NULL,
+    "allowed_units" TEXT[] NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "ingredient_catalog_pkey" PRIMARY KEY ("id")
+);
+
+-- Backfill catalog rows from existing pantry ingredient names before renaming
+-- the user-owned rows. Existing free-text names become catalog entries.
+INSERT INTO "ingredient_catalog" (
+    "id",
+    "name",
+    "category",
+    "default_unit",
+    "allowed_units",
+    "created_at",
+    "updated_at"
+)
+SELECT
+    gen_random_uuid(),
+    "name",
+    NULL,
+    COALESCE(
+        (ARRAY_AGG(DISTINCT NULLIF("unit", '') ORDER BY NULLIF("unit", '')) FILTER (WHERE NULLIF("unit", '') IS NOT NULL))[1],
+        'unit'
+    ),
+    COALESCE(
+        ARRAY_AGG(DISTINCT NULLIF("unit", '') ORDER BY NULLIF("unit", '')) FILTER (WHERE NULLIF("unit", '') IS NOT NULL),
+        ARRAY['unit']::TEXT[]
+    ),
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+FROM "ingredients"
+GROUP BY "name";
+
+-- Seed a small MVP catalog so a fresh database has useful dropdown data.
+INSERT INTO "ingredient_catalog" ("name", "category", "default_unit", "allowed_units", "updated_at")
+VALUES
+    ('Olive oil', 'pantry', 'tbsp', ARRAY['tbsp', 'tsp', 'cups', 'ml']::TEXT[], CURRENT_TIMESTAMP),
+    ('Butter', 'dairy', 'tbsp', ARRAY['tbsp', 'sticks', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Salt', 'pantry', 'tsp', ARRAY['tsp', 'tbsp', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Pepper', 'pantry', 'tsp', ARRAY['tsp', 'tbsp', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Tomatoes', 'produce', 'whole', ARRAY['whole', 'cups', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Garlic', 'produce', 'cloves', ARRAY['cloves', 'tsp', 'tbsp', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Pasta', 'pantry', 'boxes', ARRAY['boxes', 'grams', 'servings']::TEXT[], CURRENT_TIMESTAMP),
+    ('Chicken fillets', 'protein', 'fillets', ARRAY['fillets', 'lbs', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Mushrooms', 'produce', 'cups', ARRAY['cups', 'whole', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Cream', 'dairy', 'cups', ARRAY['cups', 'ml']::TEXT[], CURRENT_TIMESTAMP),
+    ('Bread loaf', 'bakery', 'loaf', ARRAY['loaf', 'slices']::TEXT[], CURRENT_TIMESTAMP),
+    ('Basil leaves', 'produce', 'leaves', ARRAY['leaves', 'grams']::TEXT[], CURRENT_TIMESTAMP),
+    ('Fresh thyme', 'produce', 'sprigs', ARRAY['sprigs', 'tsp', 'tbsp']::TEXT[], CURRENT_TIMESTAMP),
+    ('Saffron threads', 'spice', 'tsp', ARRAY['tsp', 'tbsp', 'grams']::TEXT[], CURRENT_TIMESTAMP)
+ON CONFLICT ("name") DO NOTHING;
+
+-- CreateTable
+CREATE TABLE "pantry_items" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "owner_id" UUID NOT NULL,
+    "ingredient_catalog_id" UUID NOT NULL,
+    "quantity" DECIMAL(10,2) NOT NULL,
+    "unit" VARCHAR(40) NOT NULL,
+    "notes" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "pantry_items_pkey" PRIMARY KEY ("id")
+);
+
+-- Copy existing user pantry rows into the new pantry table.
+INSERT INTO "pantry_items" (
+    "id",
+    "owner_id",
+    "ingredient_catalog_id",
+    "quantity",
+    "unit",
+    "notes",
+    "created_at",
+    "updated_at"
+)
+SELECT
+    existing."id",
+    existing."owner_id",
+    catalog."id",
+    COALESCE(existing."quantity", 0),
+    COALESCE(NULLIF(existing."unit", ''), catalog."default_unit"),
+    existing."notes",
+    existing."created_at",
+    existing."updated_at"
+FROM "ingredients" existing
+JOIN "ingredient_catalog" catalog ON catalog."name" = existing."name";
+
+-- Drop old pantry table after backfill.
+DROP TABLE "ingredients";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ingredient_catalog_name_key" ON "ingredient_catalog"("name");
+
+-- CreateIndex
+CREATE INDEX "pantry_items_owner_id_idx" ON "pantry_items"("owner_id");
+
+-- CreateIndex
+CREATE INDEX "pantry_items_ingredient_catalog_id_idx" ON "pantry_items"("ingredient_catalog_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pantry_items_owner_id_ingredient_catalog_id_unit_key" ON "pantry_items"("owner_id", "ingredient_catalog_id", "unit");
+
+-- AddForeignKey
+ALTER TABLE "pantry_items" ADD CONSTRAINT "pantry_items_owner_id_fkey" FOREIGN KEY ("owner_id") REFERENCES "profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pantry_items" ADD CONSTRAINT "pantry_items_ingredient_catalog_id_fkey" FOREIGN KEY ("ingredient_catalog_id") REFERENCES "ingredient_catalog"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- EnableRLS
+ALTER TABLE "ingredient_catalog" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "pantry_items" ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,7 +35,7 @@ model Profile {
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  ingredients                  Ingredient[]
+  pantryItems                  PantryItem[]
   ownedGroups                  Group[]            @relation("GroupOwner")
   groupMemberships             GroupMember[]
   menuRequests                 MenuRequest[]
@@ -44,21 +44,37 @@ model Profile {
   @@map("profiles")
 }
 
-model Ingredient {
-  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  ownerId   String   @map("owner_id") @db.Uuid
-  name      String   @db.VarChar(120)
-  quantity  Decimal? @db.Decimal(10, 2)
-  unit      String?  @db.VarChar(40)
-  notes     String?  @db.Text
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+model IngredientCatalog {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name         String   @unique @db.VarChar(120)
+  category     String?  @db.VarChar(80)
+  defaultUnit  String   @map("default_unit") @db.VarChar(40)
+  allowedUnits String[] @map("allowed_units")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  owner Profile @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  pantryItems PantryItem[]
 
-  @@unique([ownerId, name])
+  @@map("ingredient_catalog")
+}
+
+model PantryItem {
+  id                  String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  ownerId             String   @map("owner_id") @db.Uuid
+  ingredientCatalogId String   @map("ingredient_catalog_id") @db.Uuid
+  quantity            Decimal  @db.Decimal(10, 2)
+  unit                String   @db.VarChar(40)
+  notes               String?  @db.Text
+  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt           DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  owner      Profile           @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  ingredient IngredientCatalog @relation(fields: [ingredientCatalogId], references: [id], onDelete: Restrict)
+
+  @@unique([ownerId, ingredientCatalogId, unit])
   @@index([ownerId])
-  @@map("ingredients")
+  @@index([ingredientCatalogId])
+  @@map("pantry_items")
 }
 
 model Group {


### PR DESCRIPTION
Closes #{ISSUE_NUMBER_HERE}

## Pull Request Summary
Refactored backend lib services and demo-store helpers to use more readable names.

## Modifications
Renamed several backend service/helper functions and related types to make their purpose easier to understand.

Key renames include:

- `readBundleCandidates` -> `getBundleCandidates`
- `readGroupSettings` -> `getGroupSettings`
- `saveGroupSettings` -> `updateGroupSettings`
- `getBundleTemplates` -> `getBundles`
- `getGroupPantry` -> `getPantry`
- `getGroupRecord` -> `getDemoGroup`

This PR is intended to improve readability without changing the underlying US7/US8 behavior around group settings, missing ingredients, staples, and bundle candidate filtering.

## Testing Considerations
The services still contain several normalize and serialize helper functions. I am not fully sure how many of these are strictly necessary, but they appear to protect the backend API boundary by shaping and validating data before it is returned or saved.
 

Please look at  whether any normalize/serialize functions are redundant, and whether the renamed functions still preserve the same behavior expected by the existing routes and tests.

Suggested areas to verify:

- Group settings can still be read and updated by admins.
- Non-admin members are still blocked from updating group settings.
- Bundle candidates still respect missing-ingredient settings.
- Staples are still applied correctly when enabled.
- Existing US7/US8 tests continue to pass.

## Merge Conflict Notes
This branch is expected to conflict with newer `main` changes in `bundle-validator.ts` and `group-service.ts`.

The conflict is mostly between readability renames from this branch and newer hard-constraint validation work on `main`.

When resolving, the intended behavior is to keep the clearer renamed functions/types from this branch while preserving the hard dietary constraint logic from `main`.

In particular:

- Keep readability names such as `getBundleCandidates`, `getGroupSettings`, `updateGroupSettings`, `getBundles`, `getPantry`, and `getDemoGroup`.
- Preserve `main`’s hard constraint validation behavior from US5 ( I ended up implementing it before Leon).
- Preserve passing member constraints into bundle candidate validation.
- Preserve validation outputs such as hard-constraint failure reasons and rejected counts if they are used by the frontend/tests.

## Pull Request Checklist
- [-] Check for AI Slop
- [x] Are variable, function, class names readable?
- [-] Can you explain what the code is doing?
- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](LINK_TO_GUIDELINES)
- [ ] The summary is completed
- [ ] Assign reviewer 

