### PR TITLE
Feat: added settings tab for admin to manage staples

### DIFF
--- a/packages/backend/src/app/api/groups/[groupId]/settings/route.ts
+++ b/packages/backend/src/app/api/groups/[groupId]/settings/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { handleApiError } from "@/lib/api-response";
 import { DEMO_ADMIN_USER_ID } from "@/lib/demo-store";
 import { readGroupSettings, saveGroupSettings } from "@/lib/group-service";
-import { parseBearerToken } from "@/lib/request-user";
+import {
+  readPersistedGroupSettings,
+  savePersistedGroupSettings
+} from "@/lib/group-settings-service";
+import { isUuid, parseBearerToken } from "@/lib/request-user";
 import { getSupabaseUserFromAccessToken } from "@/lib/supabase-auth";
 
 async function getDemoOrAuthenticatedUserId(request: Request) {
@@ -17,12 +21,24 @@ async function getDemoOrAuthenticatedUserId(request: Request) {
   return request.headers.get("x-demo-user-id") ?? DEMO_ADMIN_USER_ID;
 }
 
+async function getPersistedUserId(request: Request) {
+  const token = parseBearerToken(request.headers.get("authorization"));
+  return token ? (await getSupabaseUserFromAccessToken(token)).id : null;
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ groupId: string }> },
 ) {
   try {
     const { groupId } = await params;
+    const persistedUserId = await getPersistedUserId(request);
+
+    if (persistedUserId && isUuid(groupId)) {
+      const payload = await readPersistedGroupSettings(groupId, persistedUserId);
+      return NextResponse.json(payload);
+    }
+
     const payload = readGroupSettings(groupId, await getDemoOrAuthenticatedUserId(request));
     return NextResponse.json(payload);
   } catch (error) {
@@ -69,13 +85,21 @@ export async function PATCH(
       return NextResponse.json({ error: { code: "invalidInput", message: "No supported settings were provided." } }, { status: 400 });
     }
 
-    // Only pass fields that survived validation; undefined means "do not change this setting."
-    const payload = saveGroupSettings(groupId, await getDemoOrAuthenticatedUserId(request), {
+    const persistedUserId = await getPersistedUserId(request);
+    const updates = {
       allowMissingIngredients:
         typeof body.allowMissingIngredients === "boolean" ? body.allowMissingIngredients : undefined,
       staplesEnabled: typeof body.staplesEnabled === "boolean" ? body.staplesEnabled : undefined,
       customStaples: Array.isArray(body.customStaples) ? body.customStaples : undefined,
-    });
+    };
+
+    if (persistedUserId && isUuid(groupId)) {
+      const payload = await savePersistedGroupSettings(groupId, persistedUserId, updates);
+      return NextResponse.json(payload);
+    }
+
+    // Only pass fields that survived validation; undefined means "do not change this setting."
+    const payload = saveGroupSettings(groupId, await getDemoOrAuthenticatedUserId(request), updates);
 
     return NextResponse.json(payload);
   } catch (error) {

--- a/packages/backend/src/lib/constraints/ingredients.ts
+++ b/packages/backend/src/lib/constraints/ingredients.ts
@@ -142,11 +142,39 @@ const ingredients: Ingredient[] = [
     tags: ['sodium']
   },
   {
+    id: 'pepper',
+    name: 'Pepper',
+    category: 'seasoning',
+    commonUnits: ['tsp', 'tbsp', 'g'],
+    tags: ['black pepper', 'spice']
+  },
+  {
     id: 'olive-oil',
     name: 'Olive Oil',
     category: 'oil',
     commonUnits: ['tsp', 'tbsp', 'ml'],
     tags: ['fat']
+  },
+  {
+    id: 'butter',
+    name: 'Butter',
+    category: 'dairy',
+    commonUnits: ['tbsp', 'g', 'oz'],
+    tags: ['fat', 'dairy']
+  },
+  {
+    id: 'basil-leaves',
+    name: 'Basil Leaves',
+    category: 'produce',
+    commonUnits: ['leaf', 'leaves', 'g'],
+    tags: ['basil', 'herb']
+  },
+  {
+    id: 'thyme',
+    name: 'Fresh Thyme',
+    category: 'produce',
+    commonUnits: ['sprig', 'tsp', 'g'],
+    tags: ['thyme', 'herb']
   }
 ];
 

--- a/packages/backend/src/lib/group-settings-service.test.ts
+++ b/packages/backend/src/lib/group-settings-service.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  readPersistedGroupSettings,
+  savePersistedGroupSettings
+} from './group-settings-service';
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    group: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}));
+
+vi.mock('./prisma', () => ({
+  prisma: prismaMock
+}));
+
+const GROUP_ID = '22222222-2222-4222-8222-222222222222';
+const ADMIN_ID = '11111111-1111-4111-8111-111111111111';
+const MEMBER_ID = '33333333-3333-4333-8333-333333333333';
+const now = new Date('2026-05-26T12:00:00.000Z');
+
+function membership(profileId = ADMIN_ID, role = 'ADMIN') {
+  return {
+    id: `${profileId}-membership`,
+    groupId: GROUP_ID,
+    profileId,
+    role,
+    joinedAt: now
+  };
+}
+
+function groupRecord(overrides = {}) {
+  return {
+    id: GROUP_ID,
+    ownerId: ADMIN_ID,
+    name: 'Study Dinner Crew',
+    description: 'New shared pantry group.',
+    inviteCode: 'STUDY-ABCD',
+    pantrySnapshotVersion: 1,
+    activeBundleVersion: 1,
+    selectedBundleId: null,
+    allowMissingIngredients: false,
+    staplesEnabled: false,
+    customStaples: ['salt'],
+    createdAt: now,
+    updatedAt: now,
+    members: [membership(ADMIN_ID, 'ADMIN'), membership(MEMBER_ID, 'MEMBER')],
+    ...overrides
+  };
+}
+
+describe('persisted group settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads SRD settings for an existing group member', async () => {
+    prismaMock.group.findUnique.mockResolvedValue(groupRecord());
+
+    const payload = await readPersistedGroupSettings(GROUP_ID, ADMIN_ID);
+
+    expect(payload).toMatchObject({
+      groupId: GROUP_ID,
+      groupName: 'Study Dinner Crew',
+      allowMissingIngredients: false,
+      staplesEnabled: false,
+      viewerRole: 'admin'
+    });
+    expect(payload.defaultStaplesPreset.map((item) => item.id)).toEqual([
+      'olive-oil',
+      'butter',
+      'salt',
+      'pepper'
+    ]);
+    expect(payload.customStaples).toEqual([
+      expect.objectContaining({ id: 'salt', name: 'Salt' })
+    ]);
+  });
+
+  it('allows admins to update missing-ingredient and staples settings', async () => {
+    prismaMock.group.findUnique.mockResolvedValue(groupRecord());
+    prismaMock.group.update.mockResolvedValue(
+      groupRecord({
+        allowMissingIngredients: true,
+        staplesEnabled: true,
+        customStaples: ['rice', 'salt']
+      })
+    );
+
+    const payload = await savePersistedGroupSettings(GROUP_ID, ADMIN_ID, {
+      allowMissingIngredients: true,
+      staplesEnabled: true,
+      customStaples: ['rice', 'salt', 'rice']
+    });
+
+    expect(prismaMock.group.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          allowMissingIngredients: true,
+          staplesEnabled: true,
+          customStaples: ['rice', 'salt']
+        }
+      })
+    );
+    expect(payload).toMatchObject({
+      allowMissingIngredients: true,
+      staplesEnabled: true
+    });
+    expect(payload.customStaples.map((item) => item.id)).toEqual([
+      'rice',
+      'salt'
+    ]);
+  });
+
+  it('blocks non-admin members from updating settings', async () => {
+    prismaMock.group.findUnique.mockResolvedValue(groupRecord());
+
+    await expect(
+      savePersistedGroupSettings(GROUP_ID, MEMBER_ID, {
+        staplesEnabled: true
+      })
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Only admins can update group settings.'
+    });
+    expect(prismaMock.group.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown custom staples before saving', async () => {
+    prismaMock.group.findUnique.mockResolvedValue(groupRecord());
+
+    await expect(
+      savePersistedGroupSettings(GROUP_ID, ADMIN_ID, {
+        customStaples: ['not-real']
+      })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Unknown staple ingredient id: not-real.'
+    });
+    expect(prismaMock.group.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/lib/group-settings-service.ts
+++ b/packages/backend/src/lib/group-settings-service.ts
@@ -1,0 +1,147 @@
+import type { GroupRole } from '../generated/prisma';
+import { ApiError } from './api-error';
+import {
+  findIngredientById,
+  findMissingIngredientIds,
+  listIngredients
+} from './constraints/ingredients';
+import type { IngredientSummary } from './constraints/types';
+import { prisma } from './prisma';
+import { assertUuid } from './request-user';
+
+type GroupSettingsUpdate = {
+  allowMissingIngredients?: boolean;
+  staplesEnabled?: boolean;
+  customStaples?: string[];
+};
+
+const DEFAULT_STAPLE_IDS = ['olive-oil', 'butter', 'salt', 'pepper'];
+
+function roleLabel(role: GroupRole) {
+  return role === 'MEMBER' ? 'member' : 'admin';
+}
+
+function resolveIngredientIds(ids: string[]): IngredientSummary[] {
+  return ids
+    .map((id) => findIngredientById(id))
+    .filter((ingredient): ingredient is IngredientSummary =>
+      Boolean(ingredient)
+    );
+}
+
+function normalizeStapleIds(ids: string[]) {
+  const normalizedIds = [
+    ...new Set(
+      ids
+        .map((id) => id.trim().toLowerCase())
+        .filter((id) => id.length > 0)
+    )
+  ];
+  const missingIds = findMissingIngredientIds(normalizedIds);
+
+  if (missingIds.length > 0) {
+    throw new ApiError(
+      400,
+      `Unknown staple ingredient id: ${missingIds[0]}.`
+    );
+  }
+
+  return normalizedIds;
+}
+
+async function getGroupWithMembership(
+  groupId: string,
+  profileId: string
+) {
+  assertUuid(groupId, 'groupId');
+  assertUuid(profileId, 'authenticated user id');
+
+  const group = await prisma.group.findUnique({
+    where: { id: groupId },
+    include: { members: true }
+  });
+
+  if (!group) {
+    throw new ApiError(404, 'Group not found.');
+  }
+
+  const membership = group.members.find(
+    (member) => member.profileId === profileId
+  );
+
+  if (!membership) {
+    throw new ApiError(403, 'You are not a member of this group.');
+  }
+
+  return { group, membership };
+}
+
+function serializeGroupSettings(
+  group: Awaited<ReturnType<typeof getGroupWithMembership>>['group'],
+  viewerRole: GroupRole
+) {
+  return {
+    groupId: group.id,
+    groupName: group.name,
+    allowMissingIngredients: group.allowMissingIngredients,
+    staplesEnabled: group.staplesEnabled,
+    defaultStaplesPreset: resolveIngredientIds(DEFAULT_STAPLE_IDS),
+    customStaples: resolveIngredientIds(group.customStaples ?? []),
+    ingredientCatalog: listIngredients(),
+    pantrySnapshotVersion: group.pantrySnapshotVersion,
+    activeBundleVersion: group.activeBundleVersion,
+    selectedBundleId: group.selectedBundleId,
+    updatedAt: group.updatedAt.toISOString(),
+    viewerRole: roleLabel(viewerRole)
+  };
+}
+
+export async function readPersistedGroupSettings(
+  groupId: string,
+  profileId: string
+) {
+  const { group, membership } = await getGroupWithMembership(
+    groupId,
+    profileId
+  );
+
+  return serializeGroupSettings(group, membership.role);
+}
+
+export async function savePersistedGroupSettings(
+  groupId: string,
+  profileId: string,
+  updates: GroupSettingsUpdate
+) {
+  const { membership } = await getGroupWithMembership(
+    groupId,
+    profileId
+  );
+
+  if (membership.role === 'MEMBER') {
+    throw new ApiError(
+      403,
+      'Only admins can update group settings.'
+    );
+  }
+
+  const data = {
+    ...(updates.allowMissingIngredients !== undefined
+      ? { allowMissingIngredients: updates.allowMissingIngredients }
+      : {}),
+    ...(updates.staplesEnabled !== undefined
+      ? { staplesEnabled: updates.staplesEnabled }
+      : {}),
+    ...(updates.customStaples !== undefined
+      ? { customStaples: normalizeStapleIds(updates.customStaples) }
+      : {})
+  };
+
+  const group = await prisma.group.update({
+    where: { id: groupId },
+    data,
+    include: { members: true }
+  });
+
+  return serializeGroupSettings(group, membership.role);
+}

--- a/packages/react-frontend/src/lib/httpResponse.js
+++ b/packages/react-frontend/src/lib/httpResponse.js
@@ -1,0 +1,68 @@
+function formatStatus(response) {
+  return [response.status, response.statusText]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function getNonJsonMessage(response) {
+  const status = formatStatus(response);
+
+  if (response.status === 404) {
+    return `The API endpoint was not found (${status}). Make sure the backend server is running and the Vite proxy target is correct.`;
+  }
+
+  return `The API returned ${status || 'a non-JSON response'} instead of JSON. Make sure the backend server is running and the Vite proxy target is correct.`;
+}
+
+export async function parseJsonResponse(response) {
+  if (response.status === 204) {
+    return null;
+  }
+
+  const bodyText = await response.text();
+
+  if (bodyText.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    throw new Error(getNonJsonMessage(response));
+  }
+}
+
+export function getApiErrorMessage(
+  payload,
+  fallback = 'Request failed.'
+) {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload)
+  ) {
+    if (
+      payload.error &&
+      typeof payload.error === 'object' &&
+      typeof payload.error.message === 'string'
+    ) {
+      return payload.error.message;
+    }
+
+    if (typeof payload.error === 'string') {
+      return payload.error;
+    }
+  }
+
+  return fallback;
+}
+
+export async function readJson(response) {
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(getApiErrorMessage(payload));
+  }
+
+  return payload;
+}

--- a/packages/react-frontend/src/lib/httpResponse.test.js
+++ b/packages/react-frontend/src/lib/httpResponse.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readJson } from './httpResponse.js';
+
+describe('readJson', () => {
+  it('uses API error messages from JSON responses', async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: { message: 'Invalid email or password.' }
+      }),
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: { 'content-type': 'application/json' }
+      }
+    );
+
+    await expect(readJson(response)).rejects.toThrow(
+      'Invalid email or password.'
+    );
+  });
+
+  it('replaces non-JSON 404 responses with a backend proxy hint', async () => {
+    const response = new Response('404 Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+      headers: { 'content-type': 'text/plain' }
+    });
+
+    await expect(readJson(response)).rejects.toThrow(
+      /backend server is running and the Vite proxy target is correct/i
+    );
+  });
+});

--- a/packages/react-frontend/src/pages/GroupDetailPage.jsx
+++ b/packages/react-frontend/src/pages/GroupDetailPage.jsx
@@ -1,8 +1,9 @@
 import {
   Check,
   Copy,
-  Link as LinkIcon,
   Package,
+  Plus,
+  SlidersHorizontal,
   UtensilsCrossed,
   Users,
   X
@@ -12,7 +13,9 @@ import { Link, useParams } from 'react-router-dom';
 import { StatusMessage } from '../components/StatusMessage.jsx';
 import {
   getGroup,
-  getGroupMembers
+  getGroupMembers,
+  getGroupSettings,
+  updateGroupSettings
 } from '../lib/groupApi.js';
 
 function buildInviteLink(inviteCode) {
@@ -22,6 +25,10 @@ function buildInviteLink(inviteCode) {
 function initials(member) {
   const name = member.displayName || member.email;
   return name.slice(0, 2).toUpperCase();
+}
+
+function isAdminRole(role) {
+  return ['admin', 'owner'].includes(String(role ?? '').toLowerCase());
 }
 
 function CopyButton({ text, label }) {
@@ -52,6 +59,13 @@ export function GroupDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
   const [activeTab, setActiveTab] = useState('members');
+  const [settings, setSettings] = useState(null);
+  const [isSettingsLoading, setIsSettingsLoading] = useState(false);
+  const [isSettingsSaving, setIsSettingsSaving] = useState(false);
+  const [settingsError, setSettingsError] = useState('');
+  const [settingsNotice, setSettingsNotice] = useState('');
+  const [customStaplesDraft, setCustomStaplesDraft] = useState([]);
+  const [stapleQuery, setStapleQuery] = useState('');
 
   useEffect(() => {
     if (!groupId) return undefined;
@@ -82,6 +96,147 @@ export function GroupDetailPage() {
     return () => { isCancelled = true; };
   }, [groupId]);
 
+  useEffect(() => {
+    setSettings(null);
+    setCustomStaplesDraft([]);
+    setStapleQuery('');
+    setSettingsError('');
+    setSettingsNotice('');
+  }, [groupId]);
+
+  const groupName = groupInfo?.name ?? '…';
+  const isAdmin = isAdminRole(groupInfo?.role);
+
+  useEffect(() => {
+    if (!groupId || activeTab !== 'settings' || !isAdmin || settings) {
+      return undefined;
+    }
+
+    let isCancelled = false;
+
+    async function loadGroupSettings() {
+      setIsSettingsLoading(true);
+      setSettingsError('');
+      setSettingsNotice('');
+
+      try {
+        const settingsPayload = await getGroupSettings(groupId);
+        if (isCancelled) return;
+        setSettings(settingsPayload);
+        setCustomStaplesDraft(settingsPayload.customStaples ?? []);
+      } catch (error) {
+        if (!isCancelled) {
+          setSettingsError(
+            error instanceof Error
+              ? error.message
+              : 'Unable to load group settings.'
+          );
+        }
+      } finally {
+        if (!isCancelled) setIsSettingsLoading(false);
+      }
+    }
+
+    void loadGroupSettings();
+    return () => { isCancelled = true; };
+  }, [activeTab, groupId, isAdmin, settings]);
+
+  async function saveSettingsPatch(updates, successMessage) {
+    if (!groupId) return;
+
+    setIsSettingsSaving(true);
+    setSettingsError('');
+    setSettingsNotice('');
+
+    try {
+      const nextSettings = await updateGroupSettings(groupId, updates);
+      setSettings(nextSettings);
+      setCustomStaplesDraft(nextSettings.customStaples ?? []);
+      setSettingsNotice(successMessage);
+    } catch (error) {
+      setSettingsError(
+        error instanceof Error
+          ? error.message
+          : 'Unable to save group settings.'
+      );
+    } finally {
+      setIsSettingsSaving(false);
+    }
+  }
+
+  function handleAllowMissingToggle(event) {
+    void saveSettingsPatch(
+      { allowMissingIngredients: event.target.checked },
+      'Missing ingredient setting saved.'
+    );
+  }
+
+  function handleStaplesToggle(event) {
+    void saveSettingsPatch(
+      { staplesEnabled: event.target.checked },
+      'Staples setting saved.'
+    );
+  }
+
+  function handleAddCustomStaple() {
+    if (!settings) return;
+
+    const normalizedQuery = stapleQuery.trim().toLowerCase();
+    if (!normalizedQuery) return;
+
+    const match = settings.ingredientCatalog.find((item) => {
+      const ingredientName = item.name.toLowerCase();
+      return (
+        item.id === normalizedQuery ||
+        ingredientName === normalizedQuery ||
+        ingredientName.includes(normalizedQuery)
+      );
+    });
+
+    if (!match) {
+      setSettingsNotice('');
+      setSettingsError(
+        'Pick a staple from the ingredient suggestions before adding it.'
+      );
+      return;
+    }
+
+    const isAlreadyListed =
+      settings.defaultStaplesPreset.some((item) => item.id === match.id) ||
+      customStaplesDraft.some((item) => item.id === match.id);
+
+    if (isAlreadyListed) {
+      setSettingsNotice('');
+      setSettingsError('That staple is already listed for the group.');
+      return;
+    }
+
+    setSettingsError('');
+    setSettingsNotice('');
+    setCustomStaplesDraft((current) => [...current, match]);
+    setStapleQuery('');
+  }
+
+  function handleRemoveCustomStaple(stapleId) {
+    setSettingsError('');
+    setSettingsNotice('');
+    setCustomStaplesDraft((current) =>
+      current.filter((item) => item.id !== stapleId)
+    );
+  }
+
+  function handleSaveStaples() {
+    if (!settings) return;
+
+    void saveSettingsPatch(
+      {
+        staplesEnabled: Boolean(settings.staplesEnabled),
+        customStaples: customStaplesDraft.map((item) => item.id)
+      },
+      'Staples list saved.'
+    );
+  }
+
   if (!groupId) {
     return (
       <section className="screen">
@@ -91,8 +246,8 @@ export function GroupDetailPage() {
     );
   }
 
-  const groupName = groupInfo?.name ?? '…';
-  const isAdmin = groupInfo?.role === 'Admin';
+  const canEditSettings =
+    isAdmin && (!settings?.viewerRole || isAdminRole(settings.viewerRole));
 
   // Build combined pantry: flat list of all ingredients across members
   const combinedPantry = members
@@ -156,6 +311,15 @@ export function GroupDetailPage() {
           >
             <UtensilsCrossed size={16} /> Recipes
           </button>
+          {isAdmin && (
+            <button
+              className={`gd-tab ${activeTab === 'settings' ? 'gd-tab--active' : ''}`}
+              type="button"
+              onClick={() => setActiveTab('settings')}
+            >
+              <SlidersHorizontal size={16} /> Settings
+            </button>
+          )}
         </div>
 
         {/* MEMBERS TAB */}
@@ -240,6 +404,196 @@ export function GroupDetailPage() {
               <UtensilsCrossed size={36} style={{ opacity: 0.3 }} />
               <p>Recipes coming soon.</p>
             </div>
+          </section>
+        )}
+
+        {/* SETTINGS TAB */}
+        {activeTab === 'settings' && isAdmin && (
+          <section className="gd-tab-content">
+            {isSettingsLoading ? (
+              <StatusMessage
+                type="loading"
+                title="Loading settings"
+                message="Fetching admin controls for this group."
+              />
+            ) : settings ? (
+              <>
+                <section className="settings-card surface-card">
+                  <div className="section-heading">
+                    <h2>Group Settings</h2>
+                    <span className="settings-badge">
+                      {canEditSettings ? 'Admin controls' : 'Member view'}
+                    </span>
+                  </div>
+
+                  <div className="toggle-row">
+                    <div>
+                      <h3>Allow Missing Ingredients</h3>
+                      <p>
+                        Enable bundles that include clearly disclosed shopping gaps.
+                        Disabled means missing ingredients block a candidate before it appears.
+                      </p>
+                    </div>
+
+                    <label
+                      className={`toggle-switch ${
+                        settings.allowMissingIngredients ? 'is-active' : ''
+                      } ${isSettingsSaving ? 'is-busy' : ''}`}>
+                      <input
+                        type="checkbox"
+                        aria-label="Allow Missing Ingredients"
+                        checked={Boolean(settings.allowMissingIngredients)}
+                        disabled={!canEditSettings || isSettingsSaving}
+                        onChange={handleAllowMissingToggle}
+                      />
+                      <span className="toggle-switch__track">
+                        <span className="toggle-switch__thumb" />
+                      </span>
+                    </label>
+                  </div>
+
+                  <p className="settings-note">
+                    {settings.allowMissingIngredients
+                      ? 'Candidates can appear with shopping disclosures.'
+                      : 'Only pantry-feasible candidates are shown right now.'}
+                  </p>
+                </section>
+
+                <section className="settings-card surface-card">
+                  <div className="section-heading">
+                    <h2>Pantry Staples</h2>
+                    <span className="settings-badge">
+                      {settings.staplesEnabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </div>
+
+                  <div className="toggle-row">
+                    <div>
+                      <h3>Use Group Staples</h3>
+                      <p>
+                        When enabled, approved basics are treated as effectively
+                        unlimited during group recipe generation.
+                      </p>
+                    </div>
+
+                    <label
+                      className={`toggle-switch ${
+                        settings.staplesEnabled ? 'is-active' : ''
+                      } ${isSettingsSaving ? 'is-busy' : ''}`}>
+                      <input
+                        type="checkbox"
+                        aria-label="Use Group Staples"
+                        checked={Boolean(settings.staplesEnabled)}
+                        disabled={!canEditSettings || isSettingsSaving}
+                        onChange={handleStaplesToggle}
+                      />
+                      <span className="toggle-switch__track">
+                        <span className="toggle-switch__thumb" />
+                      </span>
+                    </label>
+                  </div>
+
+                  <div className="staples-panel">
+                    <div>
+                      <h3>Default Staples Preset</h3>
+                      <div
+                        className="staple-list"
+                        aria-label="Default staples preset">
+                        {settings.defaultStaplesPreset.map((item) => (
+                          <span
+                            className="staple-chip staple-chip--default"
+                            key={item.id}>
+                            {item.name}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div>
+                      <h3>Custom Staples</h3>
+                      <p className="settings-note">
+                        Add extra ingredients the household agrees to treat like staples.
+                      </p>
+                      <div className="staple-editor">
+                        <input
+                          className="staple-search"
+                          list="staple-ingredient-suggestions"
+                          placeholder="Search ingredient suggestions"
+                          value={stapleQuery}
+                          disabled={!canEditSettings || isSettingsSaving}
+                          onChange={(event) => setStapleQuery(event.target.value)}
+                        />
+                        <datalist id="staple-ingredient-suggestions">
+                          {settings.ingredientCatalog.map((item) => (
+                            <option key={item.id} value={item.name} />
+                          ))}
+                        </datalist>
+                        <button
+                          className="button button--dark"
+                          type="button"
+                          disabled={!canEditSettings || isSettingsSaving}
+                          onClick={handleAddCustomStaple}>
+                          <Plus size={18} /> Add Staple
+                        </button>
+                      </div>
+
+                      <div
+                        className="staple-list"
+                        aria-label="Custom staples list">
+                        {customStaplesDraft.length === 0 ? (
+                          <span className="staple-chip staple-chip--empty">
+                            No custom staples yet
+                          </span>
+                        ) : (
+                          customStaplesDraft.map((item) => (
+                            <button
+                              className="staple-chip staple-chip--removable"
+                              key={item.id}
+                              type="button"
+                              disabled={!canEditSettings || isSettingsSaving}
+                              onClick={() => handleRemoveCustomStaple(item.id)}
+                              aria-label={`Remove ${item.name}`}>
+                              {item.name}
+                              <X size={14} aria-hidden="true" />
+                            </button>
+                          ))
+                        )}
+                      </div>
+
+                      <div className="settings-actions">
+                        <button
+                          className="button"
+                          type="button"
+                          disabled={!canEditSettings || isSettingsSaving}
+                          onClick={handleSaveStaples}>
+                          <Check size={18} /> Save Staples
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                {settingsNotice && (
+                  <p className="settings-status settings-status--success">
+                    {settingsNotice}
+                  </p>
+                )}
+              </>
+            ) : (
+              <StatusMessage
+                type="error"
+                title="Settings unavailable"
+                message={settingsError || 'Unable to load group settings.'}
+              />
+            )}
+
+            {settings && settingsError && (
+              <StatusMessage
+                type="error"
+                title="Settings unavailable"
+                message={settingsError}
+              />
+            )}
           </section>
         )}
     </section>

--- a/packages/react-frontend/src/pages/GroupDetailPage.test.jsx
+++ b/packages/react-frontend/src/pages/GroupDetailPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -28,27 +28,29 @@ const groupSettingsPayload = {
   viewerRole: "admin",
 };
 
-const bundleCandidatePayload = {
-  groupId: "dorm-dinner-crew",
-  groupName: "Dorm Dinner Crew",
-  allowMissingIngredients: true,
-  viewerRole: "admin",
-  filteredOutCandidateCount: 0,
-  candidates: [
+const groupInfoPayload = {
+  id: "dorm-dinner-crew",
+  name: "Dorm Dinner Crew",
+  description: "Shared pantry group.",
+  inviteCode: "DORM-1234",
+  role: "Admin",
+  members: 1,
+  pantrySnapshotVersion: 1,
+  activeBundleVersion: 1,
+  selectedBundleId: null,
+  createdAt: "2026-05-11T07:00:00.000Z",
+  updatedAt: "2026-05-11T07:00:00.000Z",
+};
+
+const groupMembersPayload = {
+  members: [
     {
-      id: "bundle-saffron-pasta-night",
-      title: "Saffron Pasta Night",
-      courses: [{ type: "main", title: "Saffron Tomato Pasta" }],
-      rationale: "Missing items are disclosed so the group can decide whether shopping is worth it.",
-      assumedStaples: [{ ingredientId: "salt", name: "Salt" }],
-      missingIngredients: [
-        {
-          ingredientId: "saffron-threads",
-          name: "Saffron threads",
-          quantityNeeded: 1,
-          unit: "tbsp",
-        },
-      ],
+      profileId: "profile-1",
+      displayName: "Vinayak",
+      email: "vinayak@example.com",
+      role: "Admin",
+      joinedAt: "2026-05-11T07:00:00.000Z",
+      ingredients: [],
     },
   ],
 };
@@ -67,9 +69,28 @@ describe("GroupDetailPage", () => {
   let fetchMock;
 
   beforeEach(() => {
-    fetchMock = vi.fn(async (input) => {
+    fetchMock = vi.fn(async (input, options) => {
       const url = String(input);
-      const payload = url.endsWith("/settings") ? groupSettingsPayload : bundleCandidatePayload;
+      let payload = groupInfoPayload;
+
+      if (url.endsWith("/members")) {
+        payload = groupMembersPayload;
+      }
+
+      if (url.endsWith("/settings")) {
+        if (options?.method === "PATCH") {
+          const body = JSON.parse(options.body);
+          payload = {
+            ...groupSettingsPayload,
+            ...body,
+            customStaples: (body.customStaples ?? groupSettingsPayload.customStaples.map((item) => item.id))
+              .map((id) => groupSettingsPayload.ingredientCatalog.find((item) => item.id === id))
+              .filter(Boolean),
+          };
+        } else {
+          payload = groupSettingsPayload;
+        }
+      }
 
       return new Response(JSON.stringify(payload), {
         status: 200,
@@ -84,8 +105,11 @@ describe("GroupDetailPage", () => {
     vi.unstubAllGlobals();
   });
 
-  it("reflects the current allowMissingIngredients setting on load", async () => {
+  it("shows the admin settings tab and reflects the current missing-ingredient setting", async () => {
+    const user = userEvent.setup();
     renderGroupDetailPage();
+
+    await user.click(await screen.findByRole("button", { name: /settings/i }));
 
     const toggle = await screen.findByRole("checkbox", {
       name: "Allow Missing Ingredients",
@@ -94,18 +118,34 @@ describe("GroupDetailPage", () => {
     expect(toggle).toBeChecked();
   });
 
-  it("shows missing ingredient disclosures on bundle cards when enabled", async () => {
+  it("saves the missing-ingredient setting from the admin tab", async () => {
+    const user = userEvent.setup();
     renderGroupDetailPage();
 
-    await screen.findByText("Saffron Pasta Night");
+    await user.click(await screen.findByRole("button", { name: /settings/i }));
+    await user.click(
+      await screen.findByRole("checkbox", {
+        name: "Allow Missing Ingredients",
+      }),
+    );
 
-    expect(screen.getByText("Missing Items")).toBeInTheDocument();
-    expect(screen.getByText("1 tbsp Saffron threads")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(
+          ([url, options]) =>
+            String(url).endsWith("/settings") &&
+            options?.method === "PATCH" &&
+            JSON.parse(options.body).allowMissingIngredients === false,
+        ),
+      ).toBe(true);
+    });
   });
 
   it("shows default staples and saves a custom staple update", async () => {
     const user = userEvent.setup();
     renderGroupDetailPage();
+
+    await user.click(await screen.findByRole("button", { name: /settings/i }));
 
     await screen.findByText("Olive oil");
     expect(screen.getByText("Basil leaves")).toBeInTheDocument();

--- a/packages/react-frontend/src/pages/GroupsPage.test.jsx
+++ b/packages/react-frontend/src/pages/GroupsPage.test.jsx
@@ -1,0 +1,290 @@
+import {
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest';
+import { GroupsPage } from './GroupsPage.jsx';
+
+const initialGroupsPayload = {
+  groups: [
+    {
+      id: 'group-1',
+      name: 'Dorm Dinner',
+      description: 'Shared pantry group.',
+      inviteCode: 'DORMD-ABCD',
+      role: 'Admin',
+      members: 3
+    }
+  ]
+};
+
+const createdGroupPayload = {
+  id: 'group-2',
+  name: 'Apartment Dinner',
+  description: 'New shared pantry group.',
+  inviteCode: 'APART-WXYZ',
+  role: 'Admin',
+  members: 1
+};
+
+describe('GroupsPage', () => {
+  let fetchMock;
+  let storage;
+
+  beforeEach(() => {
+    storage = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key) => storage.get(key) ?? null),
+      setItem: vi.fn((key, value) => {
+        storage.set(key, String(value));
+      }),
+      removeItem: vi.fn((key) => {
+        storage.delete(key);
+      }),
+      clear: vi.fn(() => {
+        storage.clear();
+      })
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue() }
+    });
+
+    localStorage.setItem(
+      'recipeCollab.session',
+      JSON.stringify({
+        profileId: '11111111-1111-4111-8111-111111111111',
+        email: 'kartik@example.com',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: 4102444800
+      })
+    );
+
+    fetchMock = vi.fn(async (input, options = {}) => {
+      const url = String(input);
+
+      if (url === '/api/groups' && options.method === 'POST') {
+        return new Response(
+          JSON.stringify(createdGroupPayload),
+          {
+            status: 201,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+
+      if (url === '/api/groups') {
+        return new Response(
+          JSON.stringify(initialGroupsPayload),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+
+      return new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderGroupsPage() {
+    render(
+      <MemoryRouter>
+        <GroupsPage />
+      </MemoryRouter>
+    );
+  }
+
+  it('opens creation from the top plus and confirms invite code copies', async () => {
+    const user = userEvent.setup();
+
+    renderGroupsPage();
+
+    expect(
+      await screen.findByText('Dorm Dinner')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/^create group$/i));
+
+    expect(
+      screen.getByRole('dialog', { name: /create group/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('DORMD-ABCD')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /copy invite code for dorm dinner/i
+      })
+    );
+
+    expect(
+      screen.getByRole('button', { name: /copied/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/groups loaded from/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('creates a group and surfaces the generated invite code', async () => {
+    const user = userEvent.setup();
+
+    renderGroupsPage();
+
+    await screen.findByText('Dorm Dinner');
+    await user.click(screen.getByLabelText(/^create group$/i));
+
+    const dialog = screen.getByRole('dialog', {
+      name: /create group/i
+    });
+    await user.type(
+      within(dialog).getByLabelText(/group name/i),
+      'Apartment Dinner'
+    );
+    await user.click(
+      within(dialog).getByLabelText(
+        /allow missing ingredients/i
+      )
+    );
+    await user.type(
+      within(dialog).getByLabelText(/custom staple/i),
+      'Rice'
+    );
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: /add staple/i
+      })
+    );
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: /^create group$/i
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/groups',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    const createCall = fetchMock.mock.calls.find(
+      ([url, options]) =>
+        String(url) === '/api/groups' &&
+        options?.method === 'POST'
+    );
+
+    expect(JSON.parse(createCall[1].body)).toEqual({
+      name: 'Apartment Dinner',
+      description: 'New shared pantry group.',
+      allowMissingIngredients: true,
+      staplesEnabled: true,
+      customStaples: ['rice']
+    });
+    expect(
+      await screen.findByText('APART-WXYZ')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/share invite code APART-WXYZ/i)
+    ).toBeInTheDocument();
+  });
+
+  it('joins by invite code with a role request', async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === '/api/groups/join') {
+        return new Response(
+          JSON.stringify({
+            id: 'group-3',
+            name: 'Project Dinner',
+            description: 'Shared pantry group.',
+            inviteCode: 'PROJE-1234',
+            role: 'Member',
+            members: 4
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+
+      return new Response(
+        JSON.stringify(initialGroupsPayload),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        }
+      );
+    });
+
+    renderGroupsPage();
+
+    await screen.findByText('Dorm Dinner');
+    await user.click(
+      screen.getByRole('button', { name: /join group/i })
+    );
+
+    const dialog = screen.getByRole('dialog', {
+      name: /join group/i
+    });
+    await user.type(
+      within(dialog).getByLabelText(/invite code/i),
+      'proje-1234'
+    );
+    await user.selectOptions(
+      within(dialog).getByLabelText(/role request/i),
+      'admin'
+    );
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: /join group/i
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/groups/join',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    const joinCall = fetchMock.mock.calls.find(
+      ([url]) => String(url) === '/api/groups/join'
+    );
+
+    expect(JSON.parse(joinCall[1].body)).toEqual({
+      inviteCode: 'PROJE-1234',
+      roleRequest: 'admin'
+    });
+    expect(
+      await screen.findByText('Project Dinner')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/admin access requested/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react-frontend/src/pages/PantryPage.jsx
+++ b/packages/react-frontend/src/pages/PantryPage.jsx
@@ -1,0 +1,442 @@
+import {
+  Database,
+  Edit3,
+  PackageOpen,
+  Plus,
+  Trash2,
+  X
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { EmptyState } from '../components/EmptyState.jsx';
+import { PageHeader } from '../components/PageHeader.jsx';
+import {
+  createPantryItem,
+  deletePantryItem,
+  getIngredientCatalog,
+  getPantryItems,
+  updatePantryItem
+} from '../lib/pantryApi.js';
+import { getSavedSession } from '../lib/session.js';
+
+const emptyDraft = {
+  ingredientName: '',
+  quantity: '1',
+  unit: ''
+};
+
+function mapCatalogIngredient(ingredient) {
+  return {
+    ...ingredient,
+    defaultUnit: ingredient.commonUnits?.[0] ?? 'units'
+  };
+}
+
+function mapApiItem(item) {
+  return {
+    id: item.id,
+    ingredientId:
+      item.canonicalIngredientId ??
+      item.name.toLowerCase().replace(/\s+/g, '-'),
+    name: item.name,
+    quantity: String(item.quantity ?? ''),
+    unit: item.unit ?? '',
+    status: 'Synced',
+    color: 'blue'
+  };
+}
+
+export function PantryPage() {
+  const [items, setItems] = useState([]);
+  const [ingredientDatabase, setIngredientDatabase] = useState(
+    []
+  );
+  const [draft, setDraft] = useState(emptyDraft);
+  const [editingId, setEditingId] = useState(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [statusMessage, setStatusMessage] = useState(
+    'Search the ingredient database before adding an item.'
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  const matchedIngredient = useMemo(() => {
+    const normalizedName = draft.ingredientName
+      .trim()
+      .toLowerCase();
+
+    return ingredientDatabase.find(
+      (ingredient) =>
+        ingredient.name.toLowerCase() === normalizedName ||
+        ingredient.id === normalizedName
+    );
+  }, [draft.ingredientName, ingredientDatabase]);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function loadPantry() {
+      setIsLoading(true);
+
+      try {
+        const catalogPayload = await getIngredientCatalog();
+
+        if (!isCancelled) {
+          setIngredientDatabase(
+            catalogPayload.ingredients.map(mapCatalogIngredient)
+          );
+        }
+
+        if (!getSavedSession()?.profileId) {
+          return;
+        }
+
+        const pantryPayload = await getPantryItems();
+
+        if (!isCancelled) {
+          setItems(pantryPayload.ingredients.map(mapApiItem));
+          setStatusMessage('Your pantry is ready.');
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          setStatusMessage(
+            error instanceof Error
+              ? error.message
+              : 'Unable to load pantry items.'
+          );
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadPantry();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  function updateDraft(event) {
+    const { name, value } = event.target;
+    setDraft((current) => {
+      const nextDraft = { ...current, [name]: value };
+
+      if (name === 'ingredientName') {
+        const nextMatch = ingredientDatabase.find(
+          (ingredient) =>
+            ingredient.name.toLowerCase() ===
+            value.trim().toLowerCase()
+        );
+
+        if (nextMatch) {
+          nextDraft.unit = nextMatch.defaultUnit;
+        }
+      }
+
+      return nextDraft;
+    });
+  }
+
+  function resetDraft() {
+    setDraft(emptyDraft);
+    setEditingId(null);
+  }
+
+  function closeDialog() {
+    setIsDialogOpen(false);
+    resetDraft();
+  }
+
+  function openAddDialog() {
+    resetDraft();
+    setStatusMessage(
+      'Search the ingredient database before adding an item.'
+    );
+    setIsDialogOpen(true);
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!matchedIngredient) {
+      setStatusMessage(
+        'Pick an ingredient from the database suggestions.'
+      );
+      return;
+    }
+
+    if (!draft.quantity || Number(draft.quantity) <= 0) {
+      setStatusMessage('Quantity must be greater than zero.');
+      return;
+    }
+
+    const duplicate = items.find(
+      (item) =>
+        item.ingredientId === matchedIngredient.id &&
+        item.id !== editingId
+    );
+
+    if (duplicate) {
+      setStatusMessage(
+        `${matchedIngredient.name} is already in your pantry. Edit the existing row instead.`
+      );
+      return;
+    }
+
+    async function saveBackendItem() {
+      try {
+        const payload = {
+          canonicalIngredientId: matchedIngredient.id,
+          name: matchedIngredient.name,
+          quantity: draft.quantity,
+          unit:
+            draft.unit.trim() || matchedIngredient.defaultUnit
+        };
+        const savedItem = editingId
+          ? await updatePantryItem(editingId, payload)
+          : await createPantryItem(payload);
+        const displayItem = mapApiItem(savedItem);
+
+        setItems((current) =>
+          editingId
+            ? current.map((item) =>
+                item.id === editingId ? displayItem : item
+              )
+            : [displayItem, ...current]
+        );
+        setStatusMessage(
+          `${matchedIngredient.name} saved to your pantry.`
+        );
+        closeDialog();
+      } catch (error) {
+        setStatusMessage(
+          error instanceof Error
+            ? error.message
+            : `Unable to save ${matchedIngredient.name}.`
+        );
+      }
+    }
+
+    void saveBackendItem();
+  }
+
+  function handleEdit(item) {
+    setEditingId(item.id);
+    setDraft({
+      ingredientName: item.name,
+      quantity: item.quantity,
+      unit: item.unit
+    });
+    setStatusMessage(`Editing ${item.name}.`);
+    setIsDialogOpen(true);
+  }
+
+  function handleDelete(itemId) {
+    const item = items.find((current) => current.id === itemId);
+
+    async function deleteBackendItem() {
+      try {
+        await deletePantryItem(itemId);
+        setStatusMessage(
+          `${item?.name ?? 'Ingredient'} removed from your pantry.`
+        );
+      } catch (error) {
+        setStatusMessage(
+          error instanceof Error
+            ? error.message
+            : `Unable to remove ${item?.name ?? 'Ingredient'}.`
+        );
+        return;
+      }
+
+      setItems((current) =>
+        current.filter(
+          (currentItem) => currentItem.id !== itemId
+        )
+      );
+    }
+
+    void deleteBackendItem();
+    if (editingId === itemId) {
+      closeDialog();
+    }
+  }
+
+  return (
+    <section className="screen pantry-screen">
+      <PageHeader
+        eyebrow="Ingredients"
+        title="My Pantry"
+        subtitle="Track the ingredients you can contribute to group meals."
+        action="plus"
+        actionLabel="Add pantry item"
+        onActionClick={openAddDialog}
+      />
+
+      <section className="pantry-summary surface-card">
+        <div>
+          <p className="eyebrow">Available</p>
+          <h2>{items.length} pantry items</h2>
+        </div>
+        <PackageOpen size={22} />
+      </section>
+
+      <p className="pantry-status">{statusMessage}</p>
+
+      <div className="section-heading profile-heading">
+        <h2>Current Ingredients</h2>
+        <button type="button">{items.length} tracked</button>
+      </div>
+
+      {isLoading ? (
+        <div className="ingredient-stack">
+          <article className="ingredient-row">
+            <span className="ingredient-dot ingredient-dot--blue">
+              ...
+            </span>
+            <div>
+              <h3>Loading pantry</h3>
+              <p>Checking saved ingredients</p>
+            </div>
+          </article>
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          title="No pantry items yet"
+          message="Add ingredients from the database to start building your pantry."
+          action={
+            <button
+              className="button"
+              type="button"
+              onClick={openAddDialog}>
+              <Plus size={18} /> Add Item
+            </button>
+          }
+        />
+      ) : (
+        <div className="ingredient-stack pantry-list">
+          {items.map((item) => (
+            <article className="ingredient-row" key={item.id}>
+              <span
+                className={`ingredient-dot ingredient-dot--${item.color}`}>
+                {item.name[0]}
+              </span>
+              <div>
+                <h3>{item.name}</h3>
+                <p>
+                  {item.quantity} {item.unit}
+                </p>
+              </div>
+              <span className="ingredient-status">
+                {item.status}
+              </span>
+              <button
+                aria-label={`Edit ${item.name}`}
+                type="button"
+                onClick={() => handleEdit(item)}>
+                <Edit3 size={18} />
+              </button>
+              <button
+                aria-label={`Delete ${item.name}`}
+                type="button"
+                onClick={() => handleDelete(item.id)}>
+                <Trash2 size={18} />
+              </button>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {isDialogOpen && (
+        <div className="dialog-backdrop">
+          <form
+            className="pantry-dialog surface-card"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="pantry-dialog-title"
+            onSubmit={handleSubmit}>
+            <div className="dialog-header">
+              <div>
+                <p className="eyebrow">Database</p>
+                <h2 id="pantry-dialog-title">
+                  {editingId
+                    ? 'Edit Pantry Item'
+                    : 'Add Pantry Item'}
+                </h2>
+              </div>
+              <button
+                className="icon-button"
+                type="button"
+                aria-label="Close"
+                onClick={closeDialog}>
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="pantry-form-grid">
+              <label className="field">
+                <span>Ingredient</span>
+                <input
+                  name="ingredientName"
+                  list="pantry-ingredient-database"
+                  value={draft.ingredientName}
+                  onChange={updateDraft}
+                  placeholder="Search ingredient database"
+                />
+              </label>
+              <datalist id="pantry-ingredient-database">
+                {ingredientDatabase.map((ingredient) => (
+                  <option
+                    key={ingredient.id}
+                    value={ingredient.name}
+                  />
+                ))}
+              </datalist>
+
+              <label className="field">
+                <span>Quantity</span>
+                <input
+                  name="quantity"
+                  type="number"
+                  min="0"
+                  step="0.25"
+                  value={draft.quantity}
+                  onChange={updateDraft}
+                />
+              </label>
+
+              <label className="field">
+                <span>Unit</span>
+                <input
+                  name="unit"
+                  value={draft.unit}
+                  onChange={updateDraft}
+                  placeholder="cups"
+                />
+              </label>
+            </div>
+
+            <p
+              className={`pantry-status ${matchedIngredient ? 'is-matched' : ''}`}>
+              {statusMessage}
+            </p>
+
+            <div className="pantry-actions">
+              <button className="button" type="submit">
+                <Plus size={18} />{' '}
+                {editingId ? 'Save Changes' : 'Add Item'}
+              </button>
+              <button
+                className="button button--dark"
+                type="button"
+                onClick={closeDialog}>
+                <X size={18} /> Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/react-frontend/src/pages/PantryPage.test.jsx
+++ b/packages/react-frontend/src/pages/PantryPage.test.jsx
@@ -1,0 +1,184 @@
+import {
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest';
+import { PantryPage } from './PantryPage.jsx';
+
+const catalogPayload = {
+  ingredients: [
+    {
+      id: 'rice',
+      name: 'Rice',
+      category: 'Grain',
+      commonUnits: ['cups']
+    },
+    {
+      id: 'shrimp',
+      name: 'Shrimp',
+      category: 'Seafood',
+      commonUnits: ['lb']
+    }
+  ]
+};
+
+const pantryPayload = {
+  ingredients: [
+    {
+      id: 'pantry-rice',
+      canonicalIngredientId: 'rice',
+      name: 'Rice',
+      quantity: '2',
+      unit: 'cups'
+    }
+  ]
+};
+
+describe('PantryPage', () => {
+  let fetchMock;
+  let storage;
+
+  beforeEach(() => {
+    storage = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key) => storage.get(key) ?? null),
+      setItem: vi.fn((key, value) => {
+        storage.set(key, String(value));
+      }),
+      removeItem: vi.fn((key) => {
+        storage.delete(key);
+      }),
+      clear: vi.fn(() => {
+        storage.clear();
+      })
+    });
+
+    localStorage.setItem(
+      'recipeCollab.session',
+      JSON.stringify({
+        profileId: '11111111-1111-4111-8111-111111111111',
+        email: 'kartik@example.com',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: 4102444800
+      })
+    );
+
+    fetchMock = vi.fn(async (input, options = {}) => {
+      const url = String(input);
+
+      if (url.startsWith('/api/ingredients/catalog')) {
+        return new Response(JSON.stringify(catalogPayload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+
+      if (
+        url === '/api/ingredients' &&
+        options.method === 'POST'
+      ) {
+        const body = JSON.parse(options.body);
+
+        return new Response(
+          JSON.stringify({
+            id: 'pantry-shrimp',
+            canonicalIngredientId: body.canonicalIngredientId,
+            name: body.name,
+            quantity: body.quantity,
+            unit: body.unit
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+
+      if (url === '/api/ingredients') {
+        return new Response(JSON.stringify(pantryPayload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+
+      return new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens a dialog and adds a pantry item from the database', async () => {
+    const user = userEvent.setup();
+
+    render(<PantryPage />);
+
+    expect(await screen.findByText('Rice')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /add pantry item/i })
+    );
+
+    const dialog = screen.getByRole('dialog', {
+      name: /add pantry item/i
+    });
+
+    await user.type(
+      within(dialog).getByLabelText(/ingredient/i),
+      'Shrimp'
+    );
+    await user.clear(
+      within(dialog).getByLabelText(/quantity/i)
+    );
+    await user.type(
+      within(dialog).getByLabelText(/quantity/i),
+      '3'
+    );
+    await user.click(
+      within(dialog).getByRole('button', { name: /add item/i })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/ingredients',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    const saveCall = fetchMock.mock.calls.find(
+      ([url, options]) =>
+        String(url) === '/api/ingredients' &&
+        options?.method === 'POST'
+    );
+
+    expect(JSON.parse(saveCall[1].body)).toEqual({
+      canonicalIngredientId: 'shrimp',
+      name: 'Shrimp',
+      quantity: '3',
+      unit: 'lb'
+    });
+    expect(
+      await screen.findByText('Shrimp')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/react-frontend/src/styles/index.css
+++ b/packages/react-frontend/src/styles/index.css
@@ -2411,6 +2411,17 @@ body {
   .constraints-card__header .button {
     width: 100%;
   }
+
+  .toggle-row,
+  .staple-editor {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .staple-editor .button {
+    width: 100%;
+  }
 }
 
 /* Group detail header */
@@ -2497,6 +2508,186 @@ body {
   padding: 18px 0;
   display: grid;
   gap: 16px;
+}
+
+/* Group admin settings */
+.settings-card {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+}
+
+.settings-card .section-heading {
+  margin-bottom: 0;
+}
+
+.settings-badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--color-line);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: var(--color-surface-strong);
+  color: var(--color-text);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.toggle-row h3,
+.staples-panel h3 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 0.96rem;
+}
+
+.toggle-row p,
+.settings-note {
+  margin: 8px 0 0;
+  color: var(--color-muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.toggle-switch {
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.toggle-switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toggle-switch__track {
+  width: 66px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  border: 1px solid var(--color-line);
+  border-radius: 999px;
+  background: var(--color-surface-strong);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.toggle-switch__thumb {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--color-text);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.toggle-switch.is-active .toggle-switch__track {
+  background: rgba(255, 90, 61, 0.2);
+  border-color: rgba(255, 90, 61, 0.55);
+}
+
+.toggle-switch.is-active .toggle-switch__thumb {
+  transform: translateX(28px);
+  background: var(--color-orange);
+}
+
+.toggle-switch.is-busy {
+  opacity: 0.7;
+}
+
+.staples-panel {
+  display: grid;
+  gap: 18px;
+  margin-top: 2px;
+}
+
+.staple-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.staple-search {
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid var(--color-line);
+  border-radius: 16px;
+  background: var(--color-surface-strong);
+  color: var(--color-text);
+  padding: 0 14px;
+  outline: none;
+}
+
+.staple-search:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
+}
+
+.staple-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.staple-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 9px 12px;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.staple-chip--default {
+  border: 1px solid rgba(156, 227, 106, 0.25);
+  background: rgba(156, 227, 106, 0.1);
+  color: var(--color-green);
+}
+
+.staple-chip--empty {
+  border: 1px dashed var(--color-line);
+  background: transparent;
+  color: var(--color-muted);
+}
+
+.staple-chip--removable {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.staple-chip--removable:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
+}
+
+.settings-actions {
+  margin-top: 14px;
+}
+
+.settings-status {
+  margin: 0;
+  border: 1px solid var(--color-line);
+  border-radius: 16px;
+  padding: 12px 14px;
+  background: var(--color-surface);
+  color: var(--color-muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.settings-status--success {
+  border-color: rgba(156, 227, 106, 0.28);
+  color: var(--color-green);
 }
 
 /* Member cards */

--- a/prisma/migrations/20260526120000_add_group_settings/migration.sql
+++ b/prisma/migrations/20260526120000_add_group_settings/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "groups"
+ADD COLUMN "allow_missing_ingredients" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "staples_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "custom_staples" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,16 +67,19 @@ model Ingredient {
 }
 
 model Group {
-  id                    String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  ownerId               String   @map("owner_id") @db.Uuid
-  name                  String   @db.VarChar(120)
-  description           String?  @db.Text
-  inviteCode            String?  @unique @map("invite_code") @db.VarChar(32)
-  pantrySnapshotVersion Int      @default(1) @map("pantry_snapshot_version")
-  activeBundleVersion   Int      @default(1) @map("active_bundle_version")
-  selectedBundleId      String?  @map("selected_bundle_id") @db.VarChar(120)
-  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+  id                      String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  ownerId                 String   @map("owner_id") @db.Uuid
+  name                    String   @db.VarChar(120)
+  description             String?  @db.Text
+  inviteCode              String?  @unique @map("invite_code") @db.VarChar(32)
+  pantrySnapshotVersion   Int      @default(1) @map("pantry_snapshot_version")
+  activeBundleVersion     Int      @default(1) @map("active_bundle_version")
+  selectedBundleId        String?  @map("selected_bundle_id") @db.VarChar(120)
+  allowMissingIngredients Boolean  @default(false) @map("allow_missing_ingredients")
+  staplesEnabled          Boolean  @default(false) @map("staples_enabled")
+  customStaples           String[] @default([]) @map("custom_staples")
+  createdAt               DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt               DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   owner        Profile       @relation("GroupOwner", fields: [ownerId], references: [id], onDelete: Restrict)
   members      GroupMember[]


### PR DESCRIPTION
Closes #{ISSUE_NUMBER_HERE}

## Pull Request Summary
Implemented Settings tab for admins to be able to modify settings for shopping tolerance, and pantry staples


## Testing Considerations
- API endpoints are hit correctly with updated settings
- settings persists from one session to the next

## Pull Request Checklist
- [ ] Check for AI Slop
- [ ] Are variable, function, class names readable?
- [ ] Can you explain what the code is doing?
- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](LINK_TO_GUIDELINES)
- [ ] The summary is completed
- [ ] Assign reviewer 

## Screenshots/Screencast
<img width="1546" height="802" alt="Screenshot 2026-05-26 at 12 14 29 PM" src="https://github.com/user-attachments/assets/e2d9da20-7a4f-470c-9cb6-fb2f60ec8c76" />
