### PR TITLE
Fix: Vite config standard import alias

### DIFF
--- a/packages/react-frontend/vite.config.js
+++ b/packages/react-frontend/vite.config.js
@@ -1,4 +1,4 @@
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
@@ -10,6 +10,11 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        "@": resolve(configDir, "src"),
+      },
+    },
     server: {
       proxy: {
         "/api": env.VITE_API_PROXY_TARGET ?? "http://127.0.0.1:3000",


### PR DESCRIPTION
Closes #{ISSUE_NUMBER_HERE}

## Pull Request Summary
Fixed standard import alias in vite config .js

## Modifications

## Testing Considerations

## Pull Request Checklist
- [x] Check for AI Slop
- [ ] Are variable, function, class names readable?
- [ ] Can you explain what the code is doing?
- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](LINK_TO_GUIDELINES)
- [ ] The summary is completed
- [x] Assign reviewer 

## Screenshots/Screencast
